### PR TITLE
Allow hhvm tests to run.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,11 @@ mysql:
   encoding: utf8
 
 before_script:
- - printf 'sendmail_path = /bin/true' > xx-php.ini
- - phpenv config-add xx-php.ini
- - pyrus channel-discover pear.drush.org
- - pyrus install drush/drush
+ - if [[ "$TRAVIS_PHP_VERSION" != hhvm* ]]; then echo 'sendmail_path = /bin/true' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi
+ # hhvm ignores sendmail_path and hhvm.mail.sendmail_path settings presently...
+ - if [[ "$TRAVIS_PHP_VERSION" == hhvm* ]]; then sudo ln -s /bin/true /usr/local/bin/sendmail; fi
+ - composer global require drush/drush:6.*
+ - export PATH="$HOME/.composer/vendor/bin:$PATH"
  - phpenv rehash
  - drush make --concurrency=5 build-lightning.make lightning
  - cd lightning


### PR DESCRIPTION
This fixes two issues blocking the hhvm tests on Travis-CI
1. phpenv doesn't have a conf.d for hhvm causing the test to abort. We could echo sendmail_path directly to /etc/hhvm/php.ini, however it doesn't appear that confs echo'd there get loaded. **Solution:** symlink /bin/true to /usr/local/bin/sendmail. Sendmail doesn't seem to be installed anyway, so this seems like an okay trick.
2. pyrus isn't installed for hhvm causing the test to abort. **Solution:** install drush globally via composer and add it to the $PATH.
