### PR TITLE
Updates jquery version to 1.10

### DIFF
--- a/lightning.install
+++ b/lightning.install
@@ -109,10 +109,10 @@ function lightning_install() {
   // Use admin theme when editing nodes.
   variable_set('node_admin_theme', '1');
 
-  // Set jQuery to version 1.7.
+  // Set jQuery to version 1.10.
   variable_set('jquery_update_compression_type', 'min');
   variable_set('jquery_update_jquery_cdn', 'none');
-  variable_set('jquery_update_jquery_version', '1.7');
+  variable_set('jquery_update_jquery_version', '1.10');
 
   // Use the source version of Modernizr since the build process can't produce
   // a minified version from the library.


### PR DESCRIPTION
[Zurb Foundation](https://www.drupal.org/project/zurb_foundation) 7.x-5.x: Utilizes Foundation 5 which requires jQuery Update running 1.10.

I have not tested thoroughly to see  if this conflicts with anything lightning_features provides...:zap:
