### PR TITLE
Improve waiting for drush runserver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ before_script:
   - drush cc all
   # Run the lightweight http server
   - drush runserver --server=builtin 8080 &
-  - sleep 4
+  - until netstat -an 2>/dev/null | grep '8080.*LISTEN'; do sleep 0.2; done
 
 script:
   # Enable the Lightning Demo


### PR DESCRIPTION
Instead of sleeping for an arbitrary period of time, poll netstat a few times a second until the server is listening for connections on 8080. 
