### PR TITLE
Patch core to fix custom elements being stripped by HTML filter

### DIFF
--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -32,3 +32,7 @@ projects[drupal][patch][] = "http://drupal.org/files/issues/drupal-2289493-3-ima
 ; when JS files are aggregated
 ; http://drupal.org/node/2400287
 projects[drupal][patch][] = "http://drupal.org/files/issues/Issue-2400287-by-hass-Remove-JS-source-and-source-map-D7_0.patch"
+
+; _filter_xss_split() fails on custom HTML elements with dashes in the name
+; http://drupal.org/node/2315255
+projects[drupal][patch][] = "https://drupal.org/files/issues/xss-split-custom-element-dash-tag-name-2315255-11.patch"


### PR DESCRIPTION
A patch to core is required in order for acquia/lightning-features/pull/21 to function properly.

https://www.drupal.org/node/2315255#comment-9661207

The one-line patch has already been committed to Drupal 8 and fixes a broken regex which prevents certain tags from being whitelisted by the "Restrict HTML Tags" filter.
