### PR TITLE
Fixed min-height of "Moderate" region in lightningdemo theme.

### DIFF
--- a/themes/lightningdemo/js/lightningdemo.js
+++ b/themes/lightningdemo/js/lightningdemo.js
@@ -2,10 +2,10 @@
 
   Drupal.behaviors.lightningdemo = {
     attach: function(context, settings) {
-
+      //sometimes the page is shorter than the off canvas moderation, so set a min height based on whatever is in the offcanvas
+      var offcanvasheight = 0; $(".left-off-canvas-menu").children().each(function(){ offcanvasheight += $(this).outerHeight(); });
+      $('.off-canvas-wrap, .left-off-canvas-menu').css('min-height', offcanvasheight + 'px');
     }
-};
+  };
 
 })(jQuery, Drupal);
-
-


### PR DESCRIPTION
This is the same fix @briancwald created for the fin theme.
