### PR TITLE
Standardize project download paths

### DIFF
--- a/drupal-org.make.yml
+++ b/drupal-org.make.yml
@@ -26,25 +26,25 @@ projects:
     download:
       type: git
       branch: 8.x-1.x
-      url: https://github.com/drupal-media/media_entity_embeddable_video.git
+    subdir: contrib/media
   media_entity_instagram:
     type: module
     download:
       type: git
       branch: 8.x-1.x
-      url: https://github.com/drupal-media/media_entity_instagram.git
+    subdir: contrib/media
   media_entity_twitter:
     type: module
     download:
       type: git
       branch: 8.x-1.x
-      url: https://github.com/drupal-media/media_entity_twitter.git
+    subdir: contrib/media
   media_entity_image:
     type: module
     download:
       type: git
       branch: 8.x-1.x
-      url: https://github.com/drupal-media/media_entity_image.git
+    subdir: contrib/media
 
   # Layout. These modules will only be enabled if the associated Lightning
   # Layout module is enabled.
@@ -69,4 +69,3 @@ projects:
       type: git
       branch: 8.x-1.x
       revision: 302fc469eb860892fc90403b5d758eb50a715f77
-


### PR DESCRIPTION
One of our makefiles was mistakenly downloading media modules a) from GitHub rather than drupal.org; and b) into /modules, rather than /modules/contrib/media. This PR fixes all that.
