### PR TITLE
Live tweets in CKEditor, and proper handling of videos

### DIFF
--- a/modules/lightning_features/lightning_media/config/install/core.entity_view_display.media.video.default.yml
+++ b/modules/lightning_features/lightning_media/config/install/core.entity_view_display.media.video.default.yml
@@ -13,7 +13,7 @@ bundle: video
 mode: default
 content:
   embed_code:
-    type: basic_string
+    type: video
     weight: 1
     label: hidden
     settings: {  }

--- a/modules/lightning_features/lightning_media/config/install/core.entity_view_display.media.video.embedded.yml
+++ b/modules/lightning_features/lightning_media/config/install/core.entity_view_display.media.video.embedded.yml
@@ -6,13 +6,15 @@ dependencies:
     - field.field.media.video.embed_code
     - field.field.media.video.field_media_in_library
     - media_entity.bundle.video
+  module:
+    - media_entity_embeddable_video
 id: media.video.embedded
 targetEntityType: media
 bundle: video
 mode: embedded
 content:
   embed_code:
-    type: basic_string
+    type: video
     weight: 0
     label: hidden
     settings: {  }

--- a/modules/lightning_features/lightning_media/src/Plugin/CKEditorPlugin/MediaLibrary.php
+++ b/modules/lightning_features/lightning_media/src/Plugin/CKEditorPlugin/MediaLibrary.php
@@ -75,6 +75,7 @@ class MediaLibrary extends EmbedCKEditorPluginBase {
     return [
       'lightning_media/backbone.facetr',
       'lightning_media/media_library',
+      'media_entity_twitter/integration',
     ];
   }
 


### PR DESCRIPTION
This PR adds two things:

1) media_entity_embeddable_video finally added a basic -- VERY basic -- video formatter, so video entities are displayed that way in their default and embedded view modes (as opposed to dumbly displaying the raw embed code).

2) media_entity_twitter's JavaScript layer was refactored in such a way that tweets embedded into CKEditor can be live-loaded.
