### PR TITLE
Non-image media assets should display titles

### DIFF
--- a/modules/lightning_features/lightning_media/js/DrupalEntity.js
+++ b/modules/lightning_features/lightning_media/js/DrupalEntity.js
@@ -19,7 +19,11 @@
       this.el.setAttribute('data-entity-id', this.model.id);
       this.el.setAttribute('data-entity-label', this.model.get('label'));
       this.el.setAttribute('data-entity-uuid', this.model.get('uuid'));
+
       this.el.innerHTML = this.model.get('thumbnail');
+      if (this.model.get('bundle') !== 'Image') {
+        this.el.innerHTML += '<div>' + this.model.get('label') + '</div>';
+      }
     }
 
   });

--- a/modules/lightning_features/lightning_media/js/EntityGrid.js
+++ b/modules/lightning_features/lightning_media/js/EntityGrid.js
@@ -5,6 +5,10 @@
 
     searchTimeoutId: -1,
 
+    attributes: {
+      class: 'library'
+    },
+
     events: {
       'appear footer': 'onFooterAppear',
       'keyup header input[type = "search"]': 'onSearch'

--- a/modules/lightning_features/lightning_media/js/MediaLibrary.js
+++ b/modules/lightning_features/lightning_media/js/MediaLibrary.js
@@ -80,7 +80,6 @@
       var nav = document.createElement('ul');
 
       this.library.$el
-        .addClass('library')
         .prop('id', this.randomId())
         .appendTo(this.el);
 
@@ -88,7 +87,6 @@
         .appendTo(nav);
 
       this.upload.$el
-        .addClass('upload')
         .prop('id', this.randomId())
         .appendTo(this.el);
 

--- a/modules/lightning_features/lightning_media/js/Uploader.js
+++ b/modules/lightning_features/lightning_media/js/Uploader.js
@@ -3,6 +3,10 @@
 
   window.Uploader = Backbone.View.extend({
 
+    attributes: {
+      class: 'upload'
+    },
+
     /**
      * The uploaded file entity, as returned from the server.
      */


### PR DESCRIPTION
Just what it says -- this fix should make the titles of non-images (tweets, instagrams, videos, etc.) show up below their thumbnails in the media library.
