### PR TITLE
Make feature branch CI actually work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,8 @@ install:
 
   # Generate the file containing build-specific overrides for drush make.
   - ./env.sh
-  # Build drupal + lightning from makefile
-  - drush make --concurrency=5 build-lightning.make.yml docroot -y
+  # Build drupal + lightning from makefile, with overrides in env.yml
+  - drush make --includes=env.yml --concurrency=5 build-lightning.make.yml docroot -y
 
   # Install lightning
   - cd docroot

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,8 @@ install:
   - phpenv config-add drupal.php.ini
   - phpenv rehash
 
-  # - echo "projects:{lightning:{download:{branch: $TRAVIS_BRANCH, url: https://github.com/$TRAVIS_REPO_SLUG.git}}}" >> env.yml
+  # Generate the file containing build-specific overrides for drush make.
+  - ./env.sh
   # Build drupal + lightning from makefile
   - drush make --concurrency=5 build-lightning.make.yml docroot -y
 

--- a/build-lightning.make.yml
+++ b/build-lightning.make.yml
@@ -2,8 +2,6 @@ api: 2
 core: 8.x
 includes:
   - drupal-org-core.make.yml
-overrides:
-  - env.yml
 projects:
   lightning:
     type: profile

--- a/build-lightning.make.yml
+++ b/build-lightning.make.yml
@@ -2,6 +2,8 @@ api: 2
 core: 8.x
 includes:
   - drupal-org-core.make.yml
+overrides:
+  - env.yml
 projects:
   lightning:
     type: profile

--- a/env.sh
+++ b/env.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-echo -e "projects:{lightning:{download:{branch: $TRAVIS_BRANCH, url: https://github.com/$TRAVIS_REPO_SLUG.git}}}" >> env.yml
+echo "projects:{lightning:{download:{branch: $TRAVIS_BRANCH, url: https://github.com/$TRAVIS_REPO_SLUG.git}}}" >> env.yml

--- a/env.sh
+++ b/env.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
-CI_BRANCH=`git symbolic-ref --short HEAD`
+git branch -a
+CI_BRANCH=`git symbolic-ref --short FETCH_HEAD`
 echo "projects: {lightning: {download: {branch: $CI_BRANCH, url: https://github.com/$TRAVIS_REPO_SLUG.git}}}" >> env.yml

--- a/env.sh
+++ b/env.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/bin/bash
 CI_BRANCH=`git symbolic-ref --short HEAD`
 echo "projects: {lightning: {download: {branch: $CI_BRANCH, url: https://github.com/$TRAVIS_REPO_SLUG.git}}}" >> env.yml

--- a/env.sh
+++ b/env.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-echo "projects:{lightning:{download:{branch: $TRAVIS_BRANCH, url: https://github.com/$TRAVIS_REPO_SLUG.git}}}" >> env.yml
+echo "projects: {lightning: {download: {branch: $TRAVIS_BRANCH, url: https://github.com/$TRAVIS_REPO_SLUG.git}}}" >> env.yml

--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo -e "projects:{lightning:{download:{branch: $TRAVIS_BRANCH, url: https://github.com/$TRAVIS_REPO_SLUG.git}}}" >> env.yml

--- a/env.sh
+++ b/env.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-echo "projects: {lightning: {download: {branch: $TRAVIS_BRANCH, url: https://github.com/$TRAVIS_REPO_SLUG.git}}}" >> env.yml
+CI_BRANCH=`git symbolic-ref --short HEAD`
+echo "projects: {lightning: {download: {branch: $CI_BRANCH, url: https://github.com/$TRAVIS_REPO_SLUG.git}}}" >> env.yml

--- a/env.yml
+++ b/env.yml
@@ -1,0 +1,2 @@
+# Build-specific overrides for drush make. See env.sh and .travis.yml.
+api: 2


### PR DESCRIPTION
Looks like having an echo statement in .travis.yml which echoes out YAML infuriated the YAML parser and broke our Travis builds. This uses an alternate approach -- .travis.yml runs a shell script which generates the appropriate overrides in env.yml.
