### PR TITLE
Add Selenium to our Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,16 @@ before_script:
   - cd tests
   - touch behat.local.yml
   - composer install
+  # Download Selenium server.
+  - wget -q http://goo.gl/PJUZfa -O selenium-server.jar
+  # Initialize xvfb (see https://docs.travis-ci.com/user/gui-and-headless-browsers)
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  # Give xvfb time to start.
+  - sleep 3
+  # Start Selenium server in the background.
+  - java -jar selenium-server.jar > /dev/null &
+  - sleep 5
 
 script:
   - bin/behat

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ script:
   - bin/behat
   - cd ../../modules/lightning_features/lightning_media/tests/js
   # TODO: The install step should go into before_script.
-  - npm install
+  - npm install > /dev/null
   - npm test
 
 notifications:


### PR DESCRIPTION
We're going to want to start writing Behat tests for JavaScript components at some point (in the not too distant future), and for that we will probably need Selenium. This PR adds the Selenium server to our .travis.yml. Along with a few minor changes to behat.yml (which I figure we can do when we actually have tests that require Selenium), this should be all we need to test JavaScript.
