### PR TITLE
Add tests for CKEditor

### DIFF
--- a/tests/features/bootstrap/FeatureContext.php
+++ b/tests/features/bootstrap/FeatureContext.php
@@ -16,41 +16,59 @@ use Behat\Behat\Tester\Exception\PendingException;
 class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext {
 
   /**
-   * Fills in WYSIWYG editor with specified ID.
+   * Asserts that a CKEditor instance exists.
    *
-   * @param string $text
-   *   The text (or HTML) to insert into the WYSIWYG.
-   * @param string $instance_id
+   * @param string $id
    *   The editor's instance ID in CKEDITOR.instances.
    *
-   * @When I fill in :text in WYSIWYG editor :instance_id
+   * @throws \Exception if the editor does not exist.
+   *
+   * @Given CKEditor :id exists
+   * @Then CKEditor :id should exist
    */
-  public function iFillInInWYSIWYGEditor($text, $instance_id)
-  {
-    $this->getSession()
-      ->executeScript("CKEDITOR.instances['$instance_id'].insertHtml('$text')");
+  public function ckeditorShouldExist($id) {
+    $exists = $this->getSession()
+      ->evaluateScript("CKEDITOR.instances.hasOwnProperty('$id');");
+
+    if (! $exists) {
+      throw new \Exception("CKEditor '$id' does not exist.");
+    }
   }
 
   /**
-   * Asserts that a WYSIWYG editor's data contains a snippet of text.
+   * Puts text or HTML into a CKEditor instance.
    *
-   * @param string $instance_id
+   * @param string $text
+   *   The text (or HTML) to insert into the editor.
+   * @param string $id
+   *   The editor's instance ID in CKEDITOR.instances.
+   *
+   * @When I put :text into CKEditor :id
+   */
+  public function iPutTextIntoCkeditor($text, $id)
+  {
+    $this->getSession()
+      ->executeScript("CKEDITOR.instances['$id'].insertHtml('$text');");
+  }
+
+  /**
+   * Asserts that a CKEditor instances's data contains a snippet of text.
+   *
+   * @param string $id
    *   The editor's instance ID in CKEDITOR.instances.
    * @param string $text
    *   The text (or HTML) snippet to look for.
    *
    * @throws \Exception if the editor doesn't contain the specified text.
    *
-   * @Then WYSIWYG editor :instance_id should contain :text
-   * @Then the WYSIWYG editor :instance_id should contain :text
-   * @Then the :instance_id WYSIWYG editor should contain :text
+   * @Then CKEditor :id should contain :text
    */
-  public function wysiwygEditorShouldContain($instance_id, $text) {
+  public function ckeditorShouldContain($id, $text) {
     $html = $this->getSession()
-      ->evaluateScript("return CKEDITOR.instances['$instance_id'].getData()");
+      ->evaluateScript("CKEDITOR.instances['$id'].getData();");
 
     if (strpos($html, $text) === FALSE) {
-      throw new \Exception("WYSIWYG editor $instance_id did not contain text $text.");
+      throw new \Exception("CKEditor $id did not contain '$text''.");
     }
   }
 

--- a/tests/features/content_type.feature
+++ b/tests/features/content_type.feature
@@ -1,4 +1,3 @@
-@lightning @content_types
 @api @lightning @content_types
   Feature: Lightning Content Types
     Makes sure that the article content type was created during installation.
@@ -8,8 +7,14 @@
     When I visit "/admin/structure/types"
     Then I should see "Basic page"
 
+  @javascript
+  Scenario: Ensure that the WYSIWYG editor is present.
+    Given I am logged in as a user with the "administrator" role
+    When I visit "node/add/page"
+    Then CKEditor "edit-body-0-value" should exist
+
   Scenario: Ensure that meta tag fields are present.
-  Given I am logged in as a user with the "administrator" role
-  When I visit "node/add/page"
-  Then I should see a "input[name='field_meta_tags[0][basic][title]']" element
-  And I should see a "input[name='field_meta_tags[0][basic][description]']" element
+    Given I am logged in as a user with the "administrator" role
+    When I visit "node/add/page"
+    Then I should see a "input[name='field_meta_tags[0][basic][title]']" element
+    And I should see a "input[name='field_meta_tags[0][basic][description]']" element


### PR DESCRIPTION
This PR adds a very simple Behat test of CKEditor. The test depends on Selenium2, but we already have that running in Travis. Once this is merged, we'll be able to do far more detailed tests of CKEditor functionality in Lightning, using CKEditor's API.
