### PR TITLE
Let Travis use the Lightning profile and modules in the repo, not from drupal.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,12 @@ install:
   - phpenv config-add drupal.php.ini
   - phpenv rehash
 
-  # - echo "projects:{lightning:{download:{branch: $TRAVIS_BRANCH, url: https://github.com/$TRAVIS_REPO_SLUG.git}}}" >> env.yml
   # Build drupal + lightning from makefile
   - drush make --concurrency=5 build-lightning.make docroot -y
+  # Copy the install profile and Lightning-specific modules in the repo, since drupal.org
+  # (which is used by drush make) is probably not as current.
+  - cp -f lightning.* docroot/profiles/lightning
+  - cp -R -f modules/lightning_features docroot/profiles/lightning/modules
 
   # Install lightning
   - cd docroot


### PR DESCRIPTION
This PR changes .travis.yml such that the installed site will use the Lightning profile (and feature modules) from the repo (and from the branch being built), rather than what's cloned from drupal.org by drush make.
