### PR TITLE
Added bash scripts to build a default local install.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /tests/bin/
 vendor/
 node_modules/
+/docroot

--- a/README.md
+++ b/README.md
@@ -91,3 +91,50 @@ of site builds will use.
     # From /profiles/lightning/modules/lightning_features/lightning_media/tests/js;
     npm install && npm test
 
+## Quick install
+
+Run `./build.sh` to use drush make to build the distribution and copy the most up to date versions of the lightning modules into the site.
+
+This will create a `/docroot`.
+
+### Setup Drupal
+
+You will then need to perform a normal Drupal 8 install.
+
+First, create a database.
+
+#### Option A: Use the script to create necessary files
+
+`./build-local-settings.php`
+
+The following default DB connection is added to `docroot/sites/default/settings.local.php` and can be updates as needed.
+
+```
+$databases['default']['default'] = [
+ 'driver' => 'mysql',
+ 'database' => 'lightning',
+ 'username' => 'root',
+ 'password' => 'password',
+ 'host' => 'localhost',
+ 'collation' => 'utf8mb4_general_ci',
+];
+```
+
+#### Option B: Manually install files
+
+Create `docroot/sites/default/settings.php` and `docroot/sites/default/services.yml`.
+
+Create a `docroot/sites/default/files` directory. Set the permissions on this directory so that the webserver can read it.
+
+For example, `chmod -R 777 docroot/sites/default/files`
+
+### Install site
+
+#### Option A: Drush
+
+`cd docroot`  
+`drush si lightning`
+
+#### Option B: Manual
+
+Open the browser to `[your-local-site]/install.php`

--- a/build-local-settings.sh
+++ b/build-local-settings.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Copy the local settings file.
+cp docroot/sites/example.settings.local.php docroot/sites/default/settings.local.php
+
+# Append a default DB to the local settings file
+cat <<HEREDOC >> docroot/sites/default/settings.local.php
+
+// For a single database configuration, the following is sufficient:
+\$databases['default']['default'] = [
+ 'driver' => 'mysql',
+ 'database' => 'lightning',
+ 'username' => 'root',
+ 'password' => 'password',
+ 'host' => 'localhost',
+ 'collation' => 'utf8mb4_general_ci',
+];
+HEREDOC
+
+# Copy the settings.php file.
+cp docroot/sites/default/default.settings.php docroot/sites/default/settings.php
+
+# Enable local settings.
+cat <<HEREDOC >> docroot/sites/default/settings.php
+
+if (file_exists(__DIR__ . '/settings.local.php')) {
+ include __DIR__ . '/settings.local.php';
+}
+HEREDOC
+
+# Copy the settings.php file.
+cp docroot/sites/default/default.services.yml docroot/sites/default/services.yml
+
+# Make the files directory.
+mkdir docroot/sites/default/files
+chmod -R 777 docroot/sites/default/files
+
+# Notify users that they want to modify their local settings.
+echo "Edit docroot/sites/default/settings.local.php with your settings."
+echo "If the defaults are ok, you can install the site by running 'drush si lightning' from /docroot."

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Build drupal + lightning from makefile
+drush make --concurrency=5 build-lightning.make docroot -y
+# Rebuild dependencies from the make file contained in the repo (not the one
+# pulled from D.O)
+drush make drupal-org.make.yml docroot/profiles/lightning --no-core -y
+# Copy the install profile and Lightning-specific modules in the repo, since drupal.org
+# (which is used by drush make) is probably not as current.
+cp -f lightning.* docroot/profiles/lightning
+cp -R -f modules/lightning_features docroot/profiles/lightning/modules
+
+# Notify users that they can use the local settings script.
+echo "Run ./build-local-settings.sh to create the necessary files for install."


### PR DESCRIPTION
I'm not sure if this fits how the project is set up, but this PR is intended to address the following concern.

When downloading the repo, setting up a site is not as simple as running `drush make`.

The travis file contains more advanced steps for the development build. Then there is also the normal Drupal set-up that you have to do for a local site.

For this reason, I've created two scripts,
`build.sh` to do what Travis does.  
`build-local-settings.sh` to do all the normal Drupal stuff.

I think there is value in `build.sh` because of the issue stated above. I think there may be value in the `build-local-settings.sh` because Lightning may be the entry point for a lot of people and knowing to create / copy those files is not the most straightforward thing in the world. This script is easy to read, commented, and will get someone set up in minutes.
