### PR TITLE
Adding front end assets to composer.json.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,15 +23,14 @@
     ],
     "scripts": {
         "post-install-cmd": [
-            "PhantomInstaller\\Installer::installPhantomJS",
-            "./bin/phing"
-        ],
-        "post-update-cmd": [
-            "./bin/phing push"
+            "PhantomInstaller\\Installer::installPhantomJS"
         ],
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold"
     },
     "extra": {
+        "asset-installer-paths": {
+          "npm-asset-library": "libraries"
+        },
         "installer-paths": {
             "docroot/core": [
                 "drupal/core"
@@ -95,6 +94,11 @@
         "drupal/services": "8.4.0-alpha3",
         "drupal-composer/drupal-scaffold": "^1.2",
         "drush/drush": "dev-master",
-        "drupal/pathauto": "^8.1.0"
+        "drupal/pathauto": "^8.1.0",
+        "fxp/composer-asset-plugin": "~1.1",
+        "npm-asset/bb-collection-view": "1.0.6",
+        "npm-asset/dropzone": "4.3.0",
+        "npm-asset/es6-promise": "3.2.1",
+        "npm-asset/jquery-appear-poetic": "0.3.6"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "4cf5ab17d49e8145c33fb76864310d92",
-    "content-hash": "5bbf71918240734c81dd66fa7b34f7f2",
+    "hash": "0fdf0f0f6a4988de95dc58100ee22b76",
+    "content-hash": "db7c38f6990db5a7bceb6bec90bee261",
     "packages": [
         {
             "name": "codegyre/robo",
@@ -1780,12 +1780,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/drush-ops/drush.git",
-                "reference": "5f5f9cf405ca131eb1f8341f76a8b429d002329e"
+                "reference": "1860a8de960b872f8282282197259b35850402df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drush-ops/drush/zipball/5f5f9cf405ca131eb1f8341f76a8b429d002329e",
-                "reference": "5f5f9cf405ca131eb1f8341f76a8b429d002329e",
+                "url": "https://api.github.com/repos/drush-ops/drush/zipball/1860a8de960b872f8282282197259b35850402df",
+                "reference": "1860a8de960b872f8282282197259b35850402df",
                 "shasum": ""
             },
             "require": {
@@ -1875,7 +1875,7 @@
             ],
             "description": "Drush is a command line shell and scripting interface for Drupal, a veritable Swiss Army knife designed to make life easier for those of us who spend some of our working hours hacking away at the command prompt.",
             "homepage": "http://www.drush.org",
-            "time": "2016-04-16 16:51:13"
+            "time": "2016-04-21 20:00:28"
         },
         {
             "name": "easyrdf/easyrdf",
@@ -1991,6 +1991,62 @@
                 "validator"
             ],
             "time": "2015-11-11 03:28:32"
+        },
+        {
+            "name": "fxp/composer-asset-plugin",
+            "version": "v1.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/francoispluchino/composer-asset-plugin.git",
+                "reference": "c3d803cc890fad5a7fb61a4036c5d973faae34af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/francoispluchino/composer-asset-plugin/zipball/c3d803cc890fad5a7fb61a4036c5d973faae34af",
+                "reference": "c3d803cc890fad5a7fb61a4036c5d973faae34af",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0",
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "composer/composer": "^1.0.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Fxp\\Composer\\AssetPlugin\\FxpAssetPlugin",
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Fxp\\Composer\\AssetPlugin\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Pluchino",
+                    "email": "francois.pluchino@gmail.com"
+                }
+            ],
+            "description": "NPM/Bower Dependency Manager for Composer",
+            "homepage": "https://github.com/francoispluchino/composer-asset-plugin",
+            "keywords": [
+                "asset",
+                "bower",
+                "composer",
+                "dependency manager",
+                "nodejs",
+                "npm",
+                "package"
+            ],
+            "time": "2016-04-22 08:48:58"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -2580,6 +2636,467 @@
                 "php"
             ],
             "time": "2016-04-19 13:41:41"
+        },
+        {
+            "name": "npm-asset/backbone",
+            "version": "1.3.3",
+            "dist": {
+                "type": "tar",
+                "url": "https://registry.npmjs.org/backbone/-/backbone-1.3.3.tgz",
+                "reference": null,
+                "shasum": "4cc80ea7cb1631ac474889ce40f2f8bc683b2999"
+            },
+            "require": {
+                "npm-asset/underscore": ">=1.8.3"
+            },
+            "require-dev": {
+                "npm-asset/coffee-script": "1.7.1",
+                "npm-asset/docco": "0.7.0",
+                "npm-asset/eslint": "dev-1.10.x|1.10.x",
+                "npm-asset/karma": ">=0.13.13,<0.14.0",
+                "npm-asset/karma-phantomjs-launcher": ">=0.1.4,<0.2.0",
+                "npm-asset/karma-qunit": ">=0.1.5,<0.2.0",
+                "npm-asset/qunitjs": ">=1.18.0,<2.0.0",
+                "npm-asset/uglify-js": ">=2.4.17,<3.0.0"
+            },
+            "type": "npm-asset-library",
+            "extra": {
+                "npm-asset-bugs": {
+                    "url": "https://github.com/jashkenas/backbone/issues"
+                },
+                "npm-asset-files": [
+                    "backbone.js",
+                    "backbone-min.js",
+                    "backbone-min.map",
+                    "LICENSE"
+                ],
+                "npm-asset-main": "backbone.js",
+                "npm-asset-directories": [],
+                "npm-asset-repository": {
+                    "type": "git",
+                    "url": "git+https://github.com/jashkenas/backbone.git"
+                },
+                "npm-asset-scripts": {
+                    "test": "karma start && coffee test/model.coffee && npm run lint",
+                    "build": "uglifyjs backbone.js --mangle --source-map backbone-min.map -o backbone-min.js",
+                    "doc": "docco backbone.js && docco examples/todos/todos.js examples/backbone.localStorage.js",
+                    "lint": "eslint backbone.js test/*.js"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jeremy Ashkenas"
+                }
+            ],
+            "description": "Give your JS App some Backbone with Models, Views, Collections, and Events.",
+            "homepage": "https://github.com/jashkenas/backbone#readme",
+            "keywords": [
+                "browser",
+                "client",
+                "controller",
+                "model",
+                "router",
+                "server",
+                "view"
+            ]
+        },
+        {
+            "name": "npm-asset/bb-collection-view",
+            "version": "1.0.6",
+            "dist": {
+                "type": "tar",
+                "url": "https://registry.npmjs.org/bb-collection-view/-/bb-collection-view-1.0.6.tgz",
+                "reference": null,
+                "shasum": "c527fec2ea0d404fe801ca8b27706c3ef1aecf63"
+            },
+            "require": {
+                "npm-asset/backbone": ">=1.2.3,<2.0.0",
+                "npm-asset/jquery": ">=2.1.1,<3.0.0",
+                "npm-asset/jquery-ui": ">=1.10.1,<2.0.0"
+            },
+            "require-dev": {
+                "npm-asset/grunt": ">=0.4.5,<0.5.0",
+                "npm-asset/grunt-contrib-compress": ">=0.13.0,<0.14.0",
+                "npm-asset/grunt-contrib-concat": ">=0.5.1,<0.6.0",
+                "npm-asset/grunt-contrib-jshint": ">=0.11.2,<0.12.0",
+                "npm-asset/grunt-contrib-uglify": ">=0.9.1,<0.10.0"
+            },
+            "type": "npm-asset-library",
+            "extra": {
+                "npm-asset-bugs": {
+                    "url": "https://github.com/rotundasoftware/backbone.collectionView/issues"
+                },
+                "npm-asset-main": "dist/backbone.collectionView.js",
+                "npm-asset-directories": [],
+                "npm-asset-repository": {
+                    "type": "git",
+                    "url": "git+https://github.com/rotundasoftware/backbone.collectionView.git"
+                },
+                "npm-asset-scripts": {
+                    "test": "open test/index.html"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Rotunda Software"
+                }
+            ],
+            "description": "Easily render backbone.js collections with support for automatic selection of models in response to clicks, reordering models via drag and drop, and more.",
+            "homepage": "https://github.com/rotundasoftware/backbone.collectionView#readme",
+            "keywords": [
+                "backbone",
+                "collection",
+                "view"
+            ]
+        },
+        {
+            "name": "npm-asset/dropzone",
+            "version": "4.3.0",
+            "dist": {
+                "type": "tar",
+                "url": "https://registry.npmjs.org/dropzone/-/dropzone-4.3.0.tgz",
+                "reference": null,
+                "shasum": "48b0b8f2ad092872e4b535b672a7c3f1a1d67c91"
+            },
+            "require-dev": {
+                "npm-asset/chai": "dev-1.7.x|1.7.x",
+                "npm-asset/grunt": ">=0.4.4,<0.5.0",
+                "npm-asset/grunt-contrib-coffee": ">=0.10.1,<0.11.0",
+                "npm-asset/grunt-contrib-concat": ">=0.4.0,<0.5.0",
+                "npm-asset/grunt-contrib-sass": ">=0.8.1,<0.9.0",
+                "npm-asset/grunt-contrib-uglify": ">=0.4.0,<0.5.0",
+                "npm-asset/grunt-contrib-watch": ">=0.6.1,<0.7.0",
+                "npm-asset/mocha": ">=1.18.2,<2.0.0",
+                "npm-asset/mocha-phantomjs": ">=3.3.2,<4.0.0",
+                "npm-asset/sinon": "1.9.1"
+            },
+            "type": "npm-asset-library",
+            "extra": {
+                "npm-asset-bugs": {
+                    "url": "https://github.com/enyo/dropzone/issues",
+                    "email": "m@tias.me"
+                },
+                "npm-asset-main": "./dist/dropzone.js",
+                "npm-asset-directories": [],
+                "npm-asset-repository": {
+                    "type": "git",
+                    "url": "git+https://github.com/enyo/dropzone.git"
+                },
+                "npm-asset-scripts": {
+                    "test": "./test.sh"
+                }
+            },
+            "authors": [
+                {
+                    "name": "Matias Meno",
+                    "email": "m@tias.me",
+                    "url": "http://www.matiasmeno.com"
+                }
+            ],
+            "description": "Handles drag and drop of files for you.",
+            "homepage": "http://www.dropzonejs.com",
+            "keywords": [
+                "drag and drop",
+                "dragndrop",
+                "file upload",
+                "upload"
+            ]
+        },
+        {
+            "name": "npm-asset/es6-promise",
+            "version": "v3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/stefanpenner/es6-promise.git",
+                "reference": "5a2a91d311944134ab3c543bf2717c9debcf6108"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/stefanpenner/es6-promise/zipball/5a2a91d311944134ab3c543bf2717c9debcf6108",
+                "reference": "5a2a91d311944134ab3c543bf2717c9debcf6108",
+                "shasum": ""
+            },
+            "require-dev": {
+                "npm-asset/babel-eslint": ">=5.0.0,<6.0.0",
+                "npm-asset/broccoli-es6-module-transpiler": ">=0.5.0,<0.6.0",
+                "npm-asset/broccoli-jshint": ">=1.1.1,<2.0.0",
+                "npm-asset/broccoli-merge-trees": ">=1.1.1,<2.0.0",
+                "npm-asset/broccoli-replace": ">=0.2.0,<0.3.0",
+                "npm-asset/broccoli-stew": ">=1.2.0,<2.0.0",
+                "npm-asset/broccoli-uglify-js": ">=0.1.3,<0.2.0",
+                "npm-asset/broccoli-watchify": ">=0.2.0,<0.3.0",
+                "npm-asset/ember-cli": "2.3.0",
+                "npm-asset/ember-publisher": "0.0.7",
+                "npm-asset/git-repo-version": "0.0.3",
+                "npm-asset/json3": ">=3.3.2,<4.0.0",
+                "npm-asset/mocha": ">=1.20.1,<2.0.0",
+                "npm-asset/promises-aplus-tests-phantom": ">=2.1.0-patch1,<3.0.0",
+                "npm-asset/release-it": "0.0.10"
+            },
+            "type": "npm-asset-library",
+            "extra": {
+                "npm-asset-bugs": {
+                    "url": "https://github.com/jakearchibald/ES6-Promises/issues"
+                },
+                "npm-asset-files": [
+                    "dist",
+                    "lib",
+                    "!dist/test"
+                ],
+                "npm-asset-main": "dist/es6-promise.js",
+                "npm-asset-directories": {
+                    "lib": "lib"
+                },
+                "npm-asset-repository": {
+                    "type": "git",
+                    "url": "git://github.com/jakearchibald/ES6-Promises.git"
+                },
+                "npm-asset-scripts": {
+                    "build": "ember build",
+                    "build:production": "ember build --environment production",
+                    "start": "ember s",
+                    "test": "ember test",
+                    "test:server": "ember test --server",
+                    "test:node": "ember build && mocha ./dist/test/browserify",
+                    "lint": "jshint lib",
+                    "prepublish": "ember build --environment production",
+                    "dry-run-release": "ember build --environment production && release-it --dry-run --non-interactive"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                "Yehuda Katz, Tom Dale, Stefan Penner and contributors (Conversion to ES6 API by Jake Archibald)"
+            ],
+            "description": "A lightweight library that provides tools for organizing asynchronous code",
+            "keywords": [
+                "futures",
+                "promises"
+            ]
+        },
+        {
+            "name": "npm-asset/jquery",
+            "version": "2.2.3",
+            "dist": {
+                "type": "tar",
+                "url": "https://registry.npmjs.org/jquery/-/jquery-2.2.3.tgz",
+                "reference": null,
+                "shasum": "45e07e4190334de36c9e1a64b43b1f1373d91758"
+            },
+            "require-dev": {
+                "npm-asset/commitplease": "2.0.0",
+                "npm-asset/core-js": "0.9.17",
+                "npm-asset/grunt": "0.4.5",
+                "npm-asset/grunt-babel": "5.0.1",
+                "npm-asset/grunt-cli": "0.1.13",
+                "npm-asset/grunt-compare-size": "0.4.0",
+                "npm-asset/grunt-contrib-jshint": "0.11.2",
+                "npm-asset/grunt-contrib-uglify": "0.9.2",
+                "npm-asset/grunt-contrib-watch": "0.6.1",
+                "npm-asset/grunt-git-authors": "2.0.1",
+                "npm-asset/grunt-jscs": "2.1.0",
+                "npm-asset/grunt-jsonlint": "1.0.4",
+                "npm-asset/grunt-npmcopy": "0.1.0",
+                "npm-asset/gzip-js": "0.3.2",
+                "npm-asset/jsdom": "5.6.1",
+                "npm-asset/load-grunt-tasks": "1.0.0",
+                "npm-asset/qunit-assert-step": "1.0.3",
+                "npm-asset/qunitjs": "1.17.1",
+                "npm-asset/requirejs": "2.1.17",
+                "npm-asset/sinon": "1.10.3",
+                "npm-asset/sizzle": "2.2.1",
+                "npm-asset/strip-json-comments": "1.0.3",
+                "npm-asset/testswarm": "1.1.0",
+                "npm-asset/win-spawn": "2.0.0"
+            },
+            "type": "npm-asset-library",
+            "extra": {
+                "npm-asset-bugs": {
+                    "url": "https://github.com/jquery/jquery/issues"
+                },
+                "npm-asset-main": "dist/jquery.js",
+                "npm-asset-directories": [],
+                "npm-asset-repository": {
+                    "type": "git",
+                    "url": "git+https://github.com/jquery/jquery.git"
+                },
+                "npm-asset-scripts": {
+                    "build": "npm install && grunt",
+                    "start": "grunt watch",
+                    "test": "grunt && grunt test"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "jQuery Foundation and other contributors",
+                    "url": "https://github.com/jquery/jquery/blob/2.2.3/AUTHORS.txt"
+                }
+            ],
+            "description": "JavaScript library for DOM operations",
+            "homepage": "http://jquery.com",
+            "keywords": [
+                "browser",
+                "javascript",
+                "jquery",
+                "library"
+            ]
+        },
+        {
+            "name": "npm-asset/jquery-appear-poetic",
+            "version": "0.3.6",
+            "dist": {
+                "type": "tar",
+                "url": "https://registry.npmjs.org/jquery-appear-poetic/-/jquery-appear-poetic-0.3.6.tgz",
+                "reference": null,
+                "shasum": "d8bc31d7b8fe9e8b23f777c47f6288bdea6f0ffc"
+            },
+            "require": {
+                "npm-asset/jquery": ">=1.5"
+            },
+            "type": "npm-asset-library",
+            "extra": {
+                "npm-asset-main": "jquery.appear.js",
+                "npm-asset-directories": [],
+                "npm-asset-scripts": []
+            },
+            "authors": [
+                {
+                    "name": "Andrey Sidorov",
+                    "email": "takandar@gmail.com",
+                    "url": "https://github.com/morr/jquery.appear/blob/master/AUTHORS.txt"
+                }
+            ],
+            "description": "It implements a custom 'appear'/'disappear' events which are fired when an element became visible/invisible in the browser view port.",
+            "homepage": "https://github.com/poetic/jquery.appear",
+            "keywords": [
+                "appear",
+                "disappear",
+                "event"
+            ]
+        },
+        {
+            "name": "npm-asset/jquery-ui",
+            "version": "1.11.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jquery/jquery-ui.git",
+                "reference": "d6713024e16de90ea71dc0544ba34e1df01b4d8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jquery/jquery-ui/zipball/d6713024e16de90ea71dc0544ba34e1df01b4d8a",
+                "reference": "d6713024e16de90ea71dc0544ba34e1df01b4d8a",
+                "shasum": ""
+            },
+            "require-dev": {
+                "npm-asset/commitplease": "1.6.0",
+                "npm-asset/grunt": "0.4.2",
+                "npm-asset/grunt-bowercopy": "1.1.0",
+                "npm-asset/grunt-compare-size": "0.4.0",
+                "npm-asset/grunt-contrib-concat": "0.1.3",
+                "npm-asset/grunt-contrib-csslint": "0.2.0",
+                "npm-asset/grunt-contrib-jshint": "0.7.1",
+                "npm-asset/grunt-contrib-qunit": "0.4.0",
+                "npm-asset/grunt-contrib-uglify": "0.1.1",
+                "npm-asset/grunt-esformatter": "0.2.0",
+                "npm-asset/grunt-git-authors": "1.2.0",
+                "npm-asset/grunt-html": "1.0.0",
+                "npm-asset/grunt-jscs": "0.6.2",
+                "npm-asset/load-grunt-tasks": "0.3.0",
+                "npm-asset/rimraf": "2.1.4",
+                "npm-asset/testswarm": "1.1.0"
+            },
+            "type": "npm-asset-library",
+            "extra": {
+                "npm-asset-bugs": "http://bugs.jqueryui.com/",
+                "npm-asset-repository": {
+                    "type": "git",
+                    "url": "git://github.com/jquery/jquery-ui.git"
+                },
+                "npm-asset-scripts": {
+                    "test": "grunt"
+                }
+            },
+            "authors": [
+                {
+                    "name": "jQuery Foundation and other contributors",
+                    "url": "https://github.com/jquery/jquery-ui/blob/1-11-stable/AUTHORS.txt"
+                }
+            ],
+            "description": "A curated set of user interface interactions, effects, widgets, and themes built on top of the jQuery JavaScript Library.",
+            "homepage": "http://jqueryui.com"
+        },
+        {
+            "name": "npm-asset/underscore",
+            "version": "1.8.3",
+            "dist": {
+                "type": "tar",
+                "url": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+                "reference": null,
+                "shasum": "4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
+            },
+            "require-dev": {
+                "npm-asset/docco": "*",
+                "npm-asset/eslint": "dev-0.6.x|0.6.x",
+                "npm-asset/karma": "~0.12.31",
+                "npm-asset/karma-qunit": "~0.1.4",
+                "npm-asset/qunit-cli": "~0.2.0",
+                "npm-asset/uglify-js": "dev-2.4.x|2.4.x"
+            },
+            "type": "npm-asset-library",
+            "extra": {
+                "npm-asset-bugs": {
+                    "url": "https://github.com/jashkenas/underscore/issues"
+                },
+                "npm-asset-files": [
+                    "underscore.js",
+                    "underscore-min.js",
+                    "underscore-min.map",
+                    "LICENSE"
+                ],
+                "npm-asset-main": "underscore.js",
+                "npm-asset-directories": [],
+                "npm-asset-repository": {
+                    "type": "git",
+                    "url": "git://github.com/jashkenas/underscore.git"
+                },
+                "npm-asset-scripts": {
+                    "test": "npm run test-node && npm run lint",
+                    "lint": "eslint underscore.js test/*.js",
+                    "test-node": "qunit-cli test/*.js",
+                    "test-browser": "npm i karma-phantomjs-launcher && ./node_modules/karma/bin/karma start",
+                    "build": "uglifyjs underscore.js -c \"evaluate=false\" --comments \"/    .*/\" -m --source-map underscore-min.map -o underscore-min.js",
+                    "doc": "docco underscore.js"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jeremy Ashkenas",
+                    "email": "jeremy@documentcloud.org"
+                }
+            ],
+            "description": "JavaScript's functional programming helper library.",
+            "homepage": "http://underscorejs.org",
+            "keywords": [
+                "browser",
+                "client",
+                "functional",
+                "server",
+                "util"
+            ]
         },
         {
             "name": "paragonie/random_compat",


### PR DESCRIPTION
Currently, simply using composer to install lightning will not build the front end dependencies. Drush make must be used, or `npm install` must be called from the lightning directory. This causes automated tests to fail.

This PR uses composer to manage front end dependencies.
