### PR TITLE
updating drupal-scaffold to 2.0.0 to help windows users

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -128,7 +128,7 @@
         "drupal/inline_entity_form": "^8.1.0",
         "drupal/metatag": "^8.1.0",
         "drupal/token": "^8.1.0",
-        "drupal-composer/drupal-scaffold": "^1.2",
+        "drupal-composer/drupal-scaffold": "^2.0.0",
         "drupal/pathauto": "^8.1.0",
         "drupal/entity_browser": "8.1.0-alpha3",
         "drupal/views_infinite_scroll": "8.1.0",


### PR DESCRIPTION
drupal-scaffold uses rsync in previous versions which causes issues for windows users.  By upgrading to 2.0.0 windows users do not need rsync
