### PR TITLE
Composer install should fail on patch failure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ install:
   # our installed versions of Drush, PHPCS, Behat, PhantomJS, etc.
   - export PATH="$TRAVIS_BUILD_DIR/bin:$PATH"
 
+  # Composer install should fail on bad patches.
+  - export COMPOSER_EXIT_ON_PATCH_FAILURE=1
+
   # MySQL Options
   - mysql -e 'SET GLOBAL wait_timeout = 5400;'
   - mysql -e "SHOW VARIABLES LIKE 'wait_timeout'"


### PR DESCRIPTION
This should fail Travis tests until https://www.drupal.org/node/2752375 is resolved.

Once that's resolved and merged into this PR, tests should pass, and this will prevent this from recurring.
