### PR TITLE
Lightning Media Image: Display id updated to image_browser for Image …

### DIFF
--- a/modules/lightning_features/lightning_media/modules/lightning_media_image/lightning_media_image.install
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_image/lightning_media_image.install
@@ -57,7 +57,7 @@ function lightning_media_image_update_8003() {
     return;
   }
 
-  $display_id = $view->addDisplay('entity_browser', 'Image Browser');
+  $display_id = $view->addDisplay('entity_browser', 'Image Browser', 'image_browser');
   $display = &$view->getDisplay($display_id);
   $display = array_merge($display, array(
     'display_options' =>


### PR DESCRIPTION
…Browser Media View.

Issue Details:
Line No. 163 : lightening_media.install file creates **new display with id entity_browser** for Media View  
Line No. 60 : lightening_media_image.install file creates new display with **same id entity_browser** for Media View

Also, Image Browser config included in Lightening Media Image Feature points to image_browser display of media view while the above approach gives 'entity_browser_2' as display id to that display.
