### PR TITLE
Support prefixing for manual URL aliases when Pathauto is enabled

### DIFF
--- a/modules/lightning_features/lightning_preview/lightning_preview.module
+++ b/modules/lightning_features/lightning_preview/lightning_preview.module
@@ -26,7 +26,11 @@ use Drupal\workbench_moderation\ModerationStateTransitionInterface as StateTrans
  */
 function lightning_preview_field_widget_info_alter(array &$info) {
   if (isset($info['path'])) {
-    $info['path']['class'] = PathWidget::class;
+    $info['path']['class'] = \Drupal::moduleHandler()->moduleExists('pathauto')
+      // We cannot use ::class here, because if Pathauto doesn't exist, PHP will
+      // blow up if we try to import the class.
+      ? '\Drupal\lightning_preview\Plugin\Field\FieldWidget\PathautoWidget'
+      : PathWidget::class;
   }
 }
 
@@ -96,11 +100,17 @@ function lightning_preview_pathauto_alias_alter(&$alias, array &$context) {
 function lightning_preview_module_implements_alter(array &$implementations, $hook) {
   $module = 'lightning_preview';
 
+  // Regarding hook_entity_presave():
   // Workbench Moderation's implementation of hook_entity_presave() screws up
   // our workspace revisioning logic, so our implementation needs to run after
   // it. We can ice this once we've ditched Workbench Moderation in favor of
   // Content Moderation.
-  if ($hook == 'entity_presave') {
+  //
+  // Regarding hook_field_widget_info_alter():
+  // Normally, Pathauto's implementation would run after ours, and it would
+  // switch the plugin to its own class. We have a special widget that extends
+  // Pathauto's, so we need to make sure it is the one that gets used.
+  if ($hook == 'entity_presave' || $hook == 'field_widget_info_alter') {
     $order = array_diff(array_keys($implementations), [$module]);
     array_push($order, $module);
     array_reorder($implementations, $order);

--- a/modules/lightning_features/lightning_preview/src/Plugin/Field/FieldWidget/PathWidget.php
+++ b/modules/lightning_features/lightning_preview/src/Plugin/Field/FieldWidget/PathWidget.php
@@ -2,39 +2,13 @@
 
 namespace Drupal\lightning_preview\Plugin\Field\FieldWidget;
 
-use Drupal\Core\Field\FieldItemListInterface;
-use Drupal\Core\Form\FormStateInterface;
-use Drupal\lightning_preview\AliasHandler;
 use Drupal\path\Plugin\Field\FieldWidget\PathWidget as BasePathWidget;
 
 /**
- * A path widget that transparently prepends the active workspace machine name.
+ * Path widget that transparently prepends the workspace machine name.
  */
 class PathWidget extends BasePathWidget {
 
-  /**
-   * {@inheritdoc}
-   */
-  public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
-    foreach ($values as $delta => $value) {
-      if ($value['alias']) {
-        $values[$delta]['alias'] = AliasHandler::addPrefix($value['alias']);
-      }
-    }
-    return parent::massageFormValues($values, $form, $form_state);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
-    $element = parent::formElement($items, $delta, $element, $form, $form_state);
-
-    // The prefixing needs to be totally transparent to the user, so strip the
-    // workspace prefix out of the default value.
-    $element['alias']['#default_value'] = AliasHandler::stripPrefix($element['alias']['#default_value']);
-
-    return $element;
-  }
+  use PathWidgetTrait;
 
 }

--- a/modules/lightning_features/lightning_preview/src/Plugin/Field/FieldWidget/PathWidgetTrait.php
+++ b/modules/lightning_features/lightning_preview/src/Plugin/Field/FieldWidget/PathWidgetTrait.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Drupal\lightning_preview\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\lightning_preview\AliasHandler;
+
+/**
+ * A path widget that transparently prepends the active workspace machine name.
+ */
+trait PathWidgetTrait {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
+    foreach ($values as $delta => $value) {
+      if ($value['alias'] && empty($value['pathauto'])) {
+        $values[$delta]['alias'] = AliasHandler::addPrefix($value['alias']);
+      }
+    }
+    return parent::massageFormValues($values, $form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+    $element = parent::formElement($items, $delta, $element, $form, $form_state);
+
+    if (empty($element['pathauto']['#default_value'])) {
+      // The prefixing needs to be totally transparent to the user, so strip the
+      // workspace prefix out of the default value.
+      $element['alias']['#default_value'] = AliasHandler::stripPrefix($element['alias']['#default_value']);
+    }
+
+    return $element;
+  }
+
+}

--- a/modules/lightning_features/lightning_preview/src/Plugin/Field/FieldWidget/PathautoWidget.php
+++ b/modules/lightning_features/lightning_preview/src/Plugin/Field/FieldWidget/PathautoWidget.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\lightning_preview\Plugin\Field\FieldWidget;
+
+use Drupal\pathauto\PathautoWidget as BasePathautoWidget;
+
+/**
+ * A path widget that transparently prepends the active workspace machine name.
+ */
+class PathautoWidget extends BasePathautoWidget {
+
+  use PathWidgetTrait;
+
+}


### PR DESCRIPTION
This PR fixes two URL alias prefixing scenarios when Pathauto is enabled:
1. If there are no applicable Pathauto rules and you enter a URL.
2. There _are_ applicable Pathauto rules, but you decide to bypass Pathauto and enter an alias manually.

This PR makes prefixing work as expected under both of these circumstances.
