### PR TITLE
Place "Page title" block in Seven theme

### DIFF
--- a/config/install/block.block.seven_page_title.yml
+++ b/config/install/block.block.seven_page_title.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  theme:
+    - seven
+id: seven_page_title
+theme: seven
+region: header
+weight: -30
+provider: null
+plugin: page_title_block
+settings:
+  id: page_title_block
+  label: 'Page title'
+  provider: core
+  label_display: '0'
+visibility: {  }


### PR DESCRIPTION
The page title is missing from the admin theme. I have copied the relevant YAML file right out of the core `standard` install profile.
