### PR TITLE
Merge PR #2392 from Drush

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,13 @@ env:
 addons:
   apt:
     packages:
-    # Trusty does not include MySQL by defualt.
+    # Trusty does not include MySQL by default.
     - mysql-server-5.6
     - mysql-client-core-5.6
     - mysql-client-5.6
+    # Dependencies for Chrome.
+    - libappindicator1
+    - fonts-liberation
 
 before_install:
   - phpenv config-rm xdebug.ini
@@ -39,6 +42,7 @@ before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
   - sleep 3
+
   # Download Chrome Driver
   - LATEST_CHROMEDRIVER=$(wget -q -O - http://chromedriver.storage.googleapis.com/LATEST_RELEASE)
   - wget http://chromedriver.storage.googleapis.com/$LATEST_CHROMEDRIVER/chromedriver_linux64.zip
@@ -47,7 +51,12 @@ before_install:
   - mkdir -p $HOME/.composer/vendor/bin
   - mv -f chromedriver $HOME/.composer/vendor/bin/
   - rm chromedriver_linux64.zip
-  # Echo Chrome version
+
+  # Update Chrome.
+  - export CHROME_BIN=/usr/bin/google-chrome
+  - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+  - sudo dpkg -i google-chrome-stable_current_amd64.deb
+  - rm google-chrome-stable_current_amd64.deb
   - google-chrome --version
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ php:
   - 5.6
 env:
   - VERSION=HEAD
-  - Version 8.x-1.11
+  - VERSION=8.x-1.11
   - VERSION=8.x-1.10
   - VERSION=8.x-1.06
   - VERSION=8.x-1.05

--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,9 @@
                 "Adding composer.json support to make-convert command":
                 "https://github.com/drush-ops/drush/commit/ce82b946d49b09cd33da5ca84feb24a6c35f8f8e.patch",
                 "The batch table may not exist by the time _drush_backend_batch_process() is called in 8.x-1.x":
-                "https://github.com/drush-ops/drush/commit/c389aebb7d3e26ff0f544684d8b3ec3528107e55.diff"
+                "https://github.com/drush-ops/drush/commit/c389aebb7d3e26ff0f544684d8b3ec3528107e55.diff",
+                "Fix composer branch-alias constraint":
+                "https://github.com/drush-ops/drush/commit/83436c8ea505223a1868dce130d4ca1b4e558711.diff"
             },
             "drupal/metatag": {
                 "2786795 - DrupalConsole integration breaks Drush":

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "3811b4a34941dc7b6c560fd67bf5a155",
-    "content-hash": "a2765cbddf8b2fa1b1fd0065e7dd0b47",
+    "hash": "e4026da779914215b7da5fa90c5cc5fe",
+    "content-hash": "d64f686d07f0ab2370771353793cf01a",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3891,16 +3891,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v1.26.1",
+            "version": "v1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "a09d8ee17ac1cfea29ed60c83960ad685c6a898d"
+                "reference": "3c6c0033fd3b5679c6e1cb60f4f9766c2b424d97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/a09d8ee17ac1cfea29ed60c83960ad685c6a898d",
-                "reference": "a09d8ee17ac1cfea29ed60c83960ad685c6a898d",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/3c6c0033fd3b5679c6e1cb60f4f9766c2b424d97",
+                "reference": "3c6c0033fd3b5679c6e1cb60f4f9766c2b424d97",
                 "shasum": ""
             },
             "require": {
@@ -3913,7 +3913,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.26-dev"
+                    "dev-master": "1.27-dev"
                 }
             },
             "autoload": {
@@ -3948,7 +3948,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2016-10-05 18:57:41"
+            "time": "2016-10-25 19:17:17"
         },
         {
             "name": "zendframework/zend-diactoros",
@@ -5022,6 +5022,11 @@
             "extra": {
                 "branch-alias": {
                     "dev-master": "9.0.x-dev"
+                },
+                "patches_applied": {
+                    "Adding composer.json support to make-convert command": "https://github.com/drush-ops/drush/commit/ce82b946d49b09cd33da5ca84feb24a6c35f8f8e.patch",
+                    "The batch table may not exist by the time _drush_backend_batch_process() is called in 8.x-1.x": "https://github.com/drush-ops/drush/commit/c389aebb7d3e26ff0f544684d8b3ec3528107e55.diff",
+                    "Fix composer branch-alias constraint": "https://github.com/drush-ops/drush/commit/83436c8ea505223a1868dce130d4ca1b4e558711.diff"
                 }
             },
             "autoload": {


### PR DESCRIPTION
According to #191, Drush's make-convert command is currently broken when dealing with certain Composer branch aliases, resulting in busted-ass makefiles being generated by our packaging script. The problem in Drush was fixed by drush-ops/drush#2392, so we need to merge that fix into our own Drush as a patch. That is what this here PR does.
