### PR TITLE
Add view mode descriptions to the Panelizer widget

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -4,6 +4,8 @@ default:
       paths:
         - %paths.base%/tests/features
       contexts:
+        - Acquia\LightningExtension\Context\DisplayModeContext
+        - Acquia\LightningExtension\Context\UndoContext
         - Drupal\DrupalExtension\Context\DrupalContext
         - Drupal\DrupalExtension\Context\MinkContext
         - Drupal\DrupalExtension\Context\MessageContext

--- a/modules/lightning_features/lightning_core/lightning_core.module
+++ b/modules/lightning_features/lightning_core/lightning_core.module
@@ -25,12 +25,11 @@ use Drupal\user\RoleInterface;
 function lightning_core_help($route_name, RouteMatchInterface $route_match) {
   $matched = [];
   // Parse the route name to figure out what display mode we're looking at:
-  //
-  // 0 = entire string
-  // 1 = view || form
-  // 2 = entity type
-  // 3 = view_mode || form_mode
-  // 4 = view || form
+  // 0 is the entire string.
+  // 1 is either 'view' or 'form'.
+  // 2 is the ID of the affected entity type.
+  // 3 is either 'view_mode' or 'form_mode'.
+  // 4 is either 'view' or 'form'.
   $expr = '/^entity\.entity_(view|form)_display\.([a-z_]+)\.((view|form)_mode)$/';
 
   if (preg_match($expr, $route_name, $matched)) {
@@ -121,9 +120,10 @@ function lightning_core_form_alter(array &$form, FormStateInterface $form_state)
   $form_object = $form_state->getFormObject();
 
   if ($form_object instanceof EntityFormInterface) {
+    $supported_operations = ['default', 'add', 'edit'];
     $entity = $form_object->getEntity();
 
-    if ($entity instanceof EntityDisplayModeInterface || $entity instanceof RoleInterface) {
+    if (($entity instanceof EntityDisplayModeInterface || $entity instanceof RoleInterface) && in_array($form_object->getOperation(), $supported_operations)) {
       $form['description'] = [
         '#type' => 'textarea',
         '#title' => t('Description'),

--- a/modules/lightning_features/lightning_layout/lightning_layout.module
+++ b/modules/lightning_features/lightning_layout/lightning_layout.module
@@ -6,8 +6,19 @@
  */
 
 use Drupal\Core\Url;
+use Drupal\lightning_layout\Plugin\Field\FieldWidget\PanelizerWidget as LightningPanelizerWidget;
 use Drupal\node\NodeTypeInterface;
+use Drupal\panelizer\Plugin\Field\FieldWidget\PanelizerWidget as BasePanelizerWidget;
 use Drupal\user\Entity\Role;
+
+/**
+ * Implements hook_field_widget_info_alter().
+ */
+function lightning_layout_field_widget_info_alter(array &$info) {
+  if ($info['panelizer']['class'] == BasePanelizerWidget::class) {
+    $info['panelizer']['class'] = LightningPanelizerWidget::class;
+  }
+}
 
 /**
  * Implements hook_form_FORM_ID_alter().
@@ -52,7 +63,12 @@ function lightning_layout_tweak_panelizer_ui(array $element) {
     '#prefix' => '<ul class="action-links">',
     '#suffix' => '</ul>',
   ];
-  array_reorder($element['panelizer'], ['enable', 'options', 'add_link', 'displays']);
+  array_reorder($element['panelizer'], [
+    'enable',
+    'options',
+    'add_link',
+    'displays',
+  ]);
 
   return $element;
 }

--- a/modules/lightning_features/lightning_layout/src/Plugin/Field/FieldWidget/PanelizerWidget.php
+++ b/modules/lightning_features/lightning_layout/src/Plugin/Field/FieldWidget/PanelizerWidget.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\lightning_layout\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Entity\Entity\EntityViewMode;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element;
+use Drupal\panelizer\Plugin\Field\FieldWidget\PanelizerWidget as BaseWidget;
+
+/**
+ * A Panelizer field widget plugin that supports view mode descriptions.
+ */
+class PanelizerWidget extends BaseWidget {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+    $element = parent::formElement($items, $delta, $element, $form, $form_state);
+
+    foreach (Element::children($element) as $i) {
+      $view_mode = $items->getEntity()->getEntityTypeId() . '.' . $element[$i]['view_mode']['#value'];
+
+      if (empty($element[$i]['default']['#description'])) {
+        $element[$i]['default']['#description'] = EntityViewMode::load($view_mode)
+          ->getThirdPartySetting('lightning_core', 'description');
+      }
+    }
+    return $element;
+  }
+
+}

--- a/src/LightningExtension/Context/DisplayModeContext.php
+++ b/src/LightningExtension/Context/DisplayModeContext.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Acquia\LightningExtension\Context;
+
+use Behat\Gherkin\Node\PyStringNode;
+use Drupal\DrupalExtension\Context\DrupalSubContextBase;
+use Drupal\DrupalExtension\Context\MinkContext;
+
+/**
+ * A context for working with entity display modes.
+ */
+class DisplayModeContext extends DrupalSubContextBase {
+
+  /**
+   * The Mink context.
+   *
+   * @var MinkContext
+   */
+  protected $minkContext;
+
+  /**
+   * Gathers required contexts.
+   *
+   * @BeforeScenario
+   */
+  public function gatherContexts() {
+    $this->minkContext = $this->getContext(MinkContext::class);
+  }
+
+  /**
+   * Sets a description on an entity view mode.
+   *
+   * @param string $id
+   *   The view mode ID.
+   * @param \Behat\Gherkin\Node\PyStringNode $description
+   *   The view mode description.
+   *
+   * @When I describe the :id view mode:
+   */
+  public function describeViewMode($id, PyStringNode $description) {
+    $this->visitPath('/admin/structure/display-modes/view/manage/' . $id);
+
+    /** @var UndoContext $undo */
+    $undo = $this->getContext(UndoContext::class);
+    if ($undo) {
+      $original = new PyStringNode(
+        (array) $this->assertSession()->fieldExists('Description')->getValue(),
+        0
+      );
+      $undo->push([$this, __FUNCTION__], [$id, $original]);
+    }
+
+    $this->minkContext->fillField('Description', (string) $description);
+    $this->minkContext->pressButton('Save');
+  }
+
+}

--- a/src/LightningExtension/Context/UndoContext.php
+++ b/src/LightningExtension/Context/UndoContext.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Acquia\LightningExtension\Context;
+
+use Behat\Behat\Context\Context;
+
+/**
+ * A context allowing easy undo of anything done during a scenario.
+ */
+class UndoContext implements Context {
+
+  /**
+   * Whether the stack is locked (i.e., not accepting new operations).
+   *
+   * @var bool
+   */
+  protected $locked = FALSE;
+
+  /**
+   * The operation stack.
+   *
+   * @var array
+   */
+  protected $stack = [];
+
+  /**
+   * Executes all undo operations in the stack.
+   *
+   * @AfterScenario
+   */
+  public function runAll() {
+    $this->locked = TRUE;
+
+    while ($this->stack) {
+      $operation = array_pop($this->stack);
+      call_user_func_array($operation[0], $operation[1]);
+    }
+
+    $this->locked = FALSE;
+  }
+
+  /**
+   * Adds an operation to the undo stack.
+   *
+   * @param callable $callback
+   *   The function to call.
+   * @param array $arguments
+   *   (optional) Arguments to pass to the callback. None of the arguments can
+   *   be passed by reference.
+   */
+  public function push(callable $callback, array $arguments = []) {
+    if ($this->locked == FALSE) {
+      $this->stack[] = func_get_args();
+    }
+  }
+
+}

--- a/tests/features/layout/panelizer.feature
+++ b/tests/features/layout/panelizer.feature
@@ -72,3 +72,12 @@ Feature: Panelizer
     And I should see "Region: left"
     And I should see "Region: right"
     Then I should not see "Region: middle"
+
+  Scenario: Describing a panelized view mode
+    Given I am logged in as a user with the administrator role
+    When I describe the node.full view mode:
+      """
+      A view mode with a description? AMAZUNG!
+      """
+    And I visit "/node/add/landing_page"
+    Then I should see "A view mode with a description? AMAZUNG!"


### PR DESCRIPTION
Partially implements #194 with a test. Also of note is that this brings in the beginnings of the fabled Lightning Extension for Behat.