### PR TITLE
Issue #2830050 by bkosborne: FileUpload widget should allow file exte…

### DIFF
--- a/modules/lightning_features/lightning_media/src/BundleResolverBase.php
+++ b/modules/lightning_features/lightning_media/src/BundleResolverBase.php
@@ -13,19 +13,14 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 abstract class BundleResolverBase extends PluginBase implements BundleResolverInterface, ContainerFactoryPluginInterface {
 
+  use SourceFieldTrait;
+
   /**
    * The media bundle entity storage handler.
    *
    * @var \Drupal\Core\Entity\EntityStorageInterface
    */
   protected $bundleStorage;
-
-  /**
-   * The configurable field entity storage handler.
-   *
-   * @var \Drupal\Core\Entity\EntityStorageInterface
-   */
-  protected $fieldStorage;
 
   /**
    * BundleResolverBase constructor.
@@ -58,35 +53,17 @@ abstract class BundleResolverBase extends PluginBase implements BundleResolverIn
   }
 
   /**
-   * Returns all possible bundles for the field type(s) this plugin supports.
-   *
-   * @return MediaBundleInterface[]
-   *   Applicable media bundles, keyed by ID.
+   * {@inheritdoc}
    */
-  protected function getPossibleBundles() {
+  public function getPossibleBundles() {
     $plugin_definition = $this->getPluginDefinition();
 
     $filter = function (MediaBundleInterface $bundle) use ($plugin_definition) {
-      $field = $this->getSourceField($bundle);
+      $field = $this->getSourceFieldForBundle($bundle);
       return $field ? in_array($field->getType(), $plugin_definition['field_types']) : FALSE;
     };
 
     return array_filter($this->bundleStorage->loadMultiple(), $filter);
-  }
-
-  /**
-   * Returns the source field for a media bundle.
-   *
-   * @param \Drupal\media_entity\MediaBundleInterface $bundle
-   *   The media bundle entity.
-   *
-   * @return \Drupal\Core\Field\FieldConfigInterface
-   *   The configurable source field entity.
-   */
-  protected function getSourceField(MediaBundleInterface $bundle) {
-    $type_config = $bundle->getType()->getConfiguration();
-    $id = 'media.' . $bundle->id() . '.' . $type_config['source_field'];
-    return $this->fieldStorage->load($id);
   }
 
 }

--- a/modules/lightning_features/lightning_media/src/BundleResolverInterface.php
+++ b/modules/lightning_features/lightning_media/src/BundleResolverInterface.php
@@ -23,4 +23,12 @@ interface BundleResolverInterface {
    */
   public function getBundle($input);
 
+  /**
+   * Returns all possible bundles for the field type(s) this plugin supports.
+   *
+   * @return MediaBundleInterface[]
+   *   Applicable media bundles, keyed by ID.
+   */
+  public function getPossibleBundles();
+
 }

--- a/modules/lightning_features/lightning_media/src/Plugin/EntityBrowser/Widget/FileUpload.php
+++ b/modules/lightning_features/lightning_media/src/Plugin/EntityBrowser/Widget/FileUpload.php
@@ -134,6 +134,9 @@ class FileUpload extends EntityFormProxy {
         [ManagedFile::class, 'processManagedFile'],
         [$this, 'processInitialFileElement'],
       ],
+      '#upload_validators' => [
+        'file_validate_extensions' => [$this->getAllowedFileUploadExtensions()],
+      ],
     );
 
     return $form;
@@ -313,6 +316,23 @@ class FileUpload extends EntityFormProxy {
 
     $command = new InvokeCommand($selector, 'empty');
     return $response->addCommand($command);
+  }
+
+  /**
+   * Returns a list of acceptable file extensions for the file upload field.
+   *
+   * @return array
+   *   The list of acceptable file extensions.
+   */
+  protected function getAllowedFileUploadExtensions() {
+    $extensions = [];
+    $possible_bundles = $this->bundleResolver->getPossibleBundles();
+    foreach ($possible_bundles as $bundle) {
+      $field = $this->getSourceFieldForBundle($bundle);
+      $extensions = array_merge($extensions, preg_split('/,?\s+/', $field->getSetting('file_extensions')));
+    }
+
+    return implode(' ', array_unique($extensions));
   }
 
   /**

--- a/modules/lightning_features/lightning_media/src/Plugin/MediaBundleResolver/FileUpload.php
+++ b/modules/lightning_features/lightning_media/src/Plugin/MediaBundleResolver/FileUpload.php
@@ -21,7 +21,7 @@ class FileUpload extends BundleResolverBase {
   public function getBundle($input) {
     if ($input instanceof FileInterface) {
       foreach ($this->getPossibleBundles() as $bundle) {
-        $field = $this->getSourceField($bundle);
+        $field = $this->getSourceFieldForBundle($bundle);
         $extensions = preg_split('/,?\s+/', $field->getSetting('file_extensions'));
 
         $extension = pathinfo($input->getFilename(), PATHINFO_EXTENSION);

--- a/modules/lightning_features/lightning_media/src/SourceFieldTrait.php
+++ b/modules/lightning_features/lightning_media/src/SourceFieldTrait.php
@@ -27,10 +27,7 @@ trait SourceFieldTrait {
    *   The source field config entity.
    */
   protected function getSourceField(MediaInterface $entity) {
-    $type_config = $entity->getType()->getConfiguration();
-    $id = $entity->getEntityTypeId() . '.' . $entity->bundle() . '.' . $type_config['source_field'];
-
-    return $this->fieldStorage->load($id);
+    return $this->getSourceFieldForBundle($entity->bundle->entity);
   }
 
   /**
@@ -44,7 +41,7 @@ trait SourceFieldTrait {
    */
   protected function getSourceFieldForBundle(MediaBundleInterface $bundle) {
     $type_config = $bundle->getType()->getConfiguration();
-    if (!isset($type_config['source_field'])) {
+    if (empty($type_config['source_field'])) {
       return NULL;
     }
     $id = 'media.' . $bundle->id() . '.' . $type_config['source_field'];

--- a/modules/lightning_features/lightning_media/src/SourceFieldTrait.php
+++ b/modules/lightning_features/lightning_media/src/SourceFieldTrait.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\lightning_media;
 
+use Drupal\media_entity\MediaBundleInterface;
 use Drupal\media_entity\MediaInterface;
 
 /**
@@ -28,6 +29,25 @@ trait SourceFieldTrait {
   protected function getSourceField(MediaInterface $entity) {
     $type_config = $entity->getType()->getConfiguration();
     $id = $entity->getEntityTypeId() . '.' . $entity->bundle() . '.' . $type_config['source_field'];
+
+    return $this->fieldStorage->load($id);
+  }
+
+  /**
+   * Returns the source field for a media bundle.
+   *
+   * @param \Drupal\media_entity\MediaBundleInterface $bundle
+   *   The media bundle entity.
+   *
+   * @return \Drupal\Core\Field\FieldConfigInterface
+   *   The configurable source field entity.
+   */
+  protected function getSourceFieldForBundle(MediaBundleInterface $bundle) {
+    $type_config = $bundle->getType()->getConfiguration();
+    if (!isset($type_config['source_field'])) {
+      return NULL;
+    }
+    $id = 'media.' . $bundle->id() . '.' . $type_config['source_field'];
 
     return $this->fieldStorage->load($id);
   }


### PR DESCRIPTION
This is to resolve this issue: https://www.drupal.org/node/2830050

This modified the `BundleResolverInterface` to expose the `getPossibleBundles()` method. I also refactored things a bit to make better use of the `SourceFieldTrait`. Not sure how comfortable you are with the API change. It seems like it would have little effect unless other users of Lightning decided to create their own bundle resolvers w/o extending the abstract one this module provides.

As for testing, I'm unable to get any of the behat tests that require JS to run on my Mac unfortunately (I installed JDK, selenium standalone server, and the chromium driver, but I still get failure to connect errors when a javascript test tries to run =/)