### PR TITLE
Fix upgrade script to account for git dependencies

### DIFF
--- a/src/UpgradeBuild.php
+++ b/src/UpgradeBuild.php
@@ -257,7 +257,7 @@ final class UpgradeBuild {
     $lock = $reader->read();
 
     foreach ($lock['packages'] as $package) {
-      if ($this->isUnofficial($package['notification-url'])) {
+      if (isset($package['notification-url']) && $this->isUnofficial($package['notification-url'])) {
         $this->drupalPackages[] = $package['name'];
       }
     }


### PR DESCRIPTION
Not all packages in a project's composer.json will have a notification URL (like those coming from a git repo)

Without this, the upgrade script was bombing it out when it came upon a package we have that's coming from a git repo we maintain/