### PR TITLE
Drupal ui standards

### DIFF
--- a/modules/lightning_features/lightning_core/config/install/lightning_core.settings.yml
+++ b/modules/lightning_features/lightning_core/config/install/lightning_core.settings.yml
@@ -1,7 +1,7 @@
 content_roles:
   creator:
     enabled: true
-    label: '? Creator'
+    label: '? creator'
     permissions:
       - 'create ? content'
       - 'edit own ? content'
@@ -10,7 +10,7 @@ content_roles:
       - 'create url aliases'
   reviewer:
     enabled: true
-    label: '? Reviewer'
+    label: '? reviewer'
     permissions:
       - 'edit any ? content'
       - 'delete any ? content'

--- a/modules/lightning_features/lightning_core/modules/lightning_page/config/install/field.field.node.page.field_meta_tags.yml
+++ b/modules/lightning_features/lightning_core/modules/lightning_page/config/install/field.field.node.page.field_meta_tags.yml
@@ -10,7 +10,7 @@ id: node.page.field_meta_tags
 field_name: field_meta_tags
 entity_type: node
 bundle: page
-label: 'Meta Tags'
+label: 'Meta tags'
 description: ''
 required: false
 translatable: false

--- a/modules/lightning_features/lightning_layout/config/install/user.role.layout_manager.yml
+++ b/modules/lightning_features/lightning_layout/config/install/user.role.layout_manager.yml
@@ -1,5 +1,5 @@
 id: layout_manager
-label: 'Layout Manager'
+label: 'Layout manager'
 weight: 2
 langcode: en
 is_admin: false

--- a/modules/lightning_features/lightning_layout/modules/lightning_landing_page/config/install/field.field.node.landing_page.field_meta_tags.yml
+++ b/modules/lightning_features/lightning_layout/modules/lightning_landing_page/config/install/field.field.node.landing_page.field_meta_tags.yml
@@ -10,7 +10,7 @@ id: node.landing_page.field_meta_tags
 field_name: field_meta_tags
 entity_type: node
 bundle: landing_page
-label: 'Meta Tags'
+label: 'Meta tags'
 description: ''
 required: false
 translatable: true

--- a/modules/lightning_features/lightning_layout/modules/lightning_landing_page/config/install/node.type.landing_page.yml
+++ b/modules/lightning_features/lightning_layout/modules/lightning_landing_page/config/install/node.type.landing_page.yml
@@ -18,7 +18,7 @@ third_party_settings:
     default_moderation_state: draft
 _core:
   default_config_hash: MWuuU2s7Yut9mzGjI8lKlsy0OIqoW8IAB5P7wqZpnjQ
-name: 'Landing Page'
+name: 'Landing page'
 type: landing_page
 description: 'A special page with its own one-off layout and content.'
 help: ''

--- a/modules/lightning_features/lightning_layout/modules/lightning_landing_page/lightning_landing_page.info.yml
+++ b/modules/lightning_features/lightning_layout/modules/lightning_landing_page/lightning_landing_page.info.yml
@@ -1,4 +1,4 @@
-name: Landing Page
+name: Landing page
 package: Lightning
 core: 8.x
 type: module

--- a/modules/lightning_features/lightning_media/config/install/core.entity_form_mode.media.media_browser.yml
+++ b/modules/lightning_features/lightning_media/config/install/core.entity_form_mode.media.media_browser.yml
@@ -4,6 +4,6 @@ dependencies:
   module:
     - media_entity
 id: media.media_browser
-label: 'Media Browser'
+label: 'Media browser'
 targetEntityType: media
 cache: true

--- a/modules/lightning_features/lightning_media/config/install/embed.button.media_browser.yml
+++ b/modules/lightning_features/lightning_media/config/install/embed.button.media_browser.yml
@@ -4,7 +4,7 @@ dependencies:
   module:
     - entity_embed
     - media_entity
-label: 'Media Browser'
+label: 'Media browser'
 id: media_browser
 type_id: entity
 type_settings:

--- a/modules/lightning_features/lightning_media/config/install/entity_browser.browser.media_browser.yml
+++ b/modules/lightning_features/lightning_media/config/install/entity_browser.browser.media_browser.yml
@@ -5,7 +5,7 @@ dependencies:
     - lightning_media
     - views
 name: media_browser
-label: 'Media Browser'
+label: 'Media browser'
 display: iframe
 display_configuration:
   path: /media-browser
@@ -32,7 +32,7 @@ widgets:
       submit_text: Place
     uuid: 8b142f33-59d1-47b1-9e3a-4ae85d8376fa
     weight: -8
-    label: 'Create Embed'
+    label: 'Create embed'
     id: embed_code
   044d2af7-314b-4830-8b6d-64896bbb861e:
     settings:

--- a/modules/lightning_features/lightning_media/config/install/user.role.media_creator.yml
+++ b/modules/lightning_features/lightning_media/config/install/user.role.media_creator.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: media_creator
-label: 'Media Creator'
+label: 'Media creator'
 weight: 5
 is_admin: null
 permissions:

--- a/modules/lightning_features/lightning_media/config/install/user.role.media_manager.yml
+++ b/modules/lightning_features/lightning_media/config/install/user.role.media_manager.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: media_manager
-label: 'Media Manager'
+label: 'Media manager'
 weight: 6
 is_admin: null
 permissions:

--- a/modules/lightning_features/lightning_preview/config/install/user.role.workspace_creator.yml
+++ b/modules/lightning_features/lightning_preview/config/install/user.role.workspace_creator.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: workspace_creator
-label: 'Workspace Creator'
+label: 'Workspace creator'
 weight: 10
 is_admin: null
 permissions:

--- a/modules/lightning_features/lightning_preview/config/install/user.role.workspace_reviewer.yml
+++ b/modules/lightning_features/lightning_preview/config/install/user.role.workspace_reviewer.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: workspace_reviewer
-label: 'Workspace Reviewer'
+label: 'Workspace reviewer'
 weight: 11
 is_admin: null
 permissions:

--- a/modules/lightning_features/lightning_workflow/config/install/views.view.moderation_history.yml
+++ b/modules/lightning_features/lightning_workflow/config/install/views.view.moderation_history.yml
@@ -5,7 +5,7 @@ dependencies:
     - node
     - user
 id: moderation_history
-label: 'Moderation History'
+label: 'Moderation history'
 module: views
 description: ''
 tag: ''

--- a/modules/lightning_features/lightning_workflow/lightning_workflow.module
+++ b/modules/lightning_features/lightning_workflow/lightning_workflow.module
@@ -86,7 +86,7 @@ function lightning_workflow_node_type_insert(NodeTypeInterface $node_type) {
       'field_name' => 'scheduled_update',
       'entity_type' => 'node',
       'bundle' => $id,
-      'label' => t('Scheduled Update'),
+      'label' => t('Scheduled update'),
       'settings' => [
         'handler' => 'default:scheduled_update',
         'handler_settings' => [


### PR DESCRIPTION
This PR is an attempt to apply a few of the Drupal UI standards to the Lightning Profile particularly around the use of capitalization. For example, on the [Interface text](https://www.drupal.org/docs/develop/user-interface-standards/interface-text) page:

> Capitalization
> 
> Page titles, links, and headings
> 
> Page titles, links, and headings in Drupal should generally use "sentence case" where only the first word is capitalized, except for proper nouns and other words which are generally capitalized by a more specific rule. Examples: "Block administration", "List menus", "Install new theme". This also applies to links in menus

I attempted to use the sentence case for Content types labels, Role labels, and Field name labels.