### PR TITLE
Remove Search API DB from Lightning profile dependencies

### DIFF
--- a/lightning.info.yml
+++ b/lightning.info.yml
@@ -42,7 +42,6 @@ dependencies:
   # contrib
   - diff
   - metatag
-  - search_api_db
   # Our own core functionality.
   - lightning_core
 

--- a/modules/lightning_features/lightning_core/modules/lightning_dev/lightning_dev.install
+++ b/modules/lightning_features/lightning_core/modules/lightning_dev/lightning_dev.install
@@ -93,8 +93,7 @@ function lightning_dev_update_8002() {
     ->unsetThirdPartySetting('panelizer', 'displays')
     ->save();
 
-  \Drupal::service('module_installer')
-    ->install(['search_api_db', 'lightning_search']);
+  \Drupal::service('module_installer')->install(['lightning_search']);
 
   \Drupal::service('lightning.content_roles')
     ->grantPermissions('reviewer', [

--- a/modules/lightning_features/lightning_core/modules/lightning_search/lightning_search.install
+++ b/modules/lightning_features/lightning_core/modules/lightning_search/lightning_search.install
@@ -13,6 +13,13 @@ use Drupal\search_api\Entity\Server;
  * Implements hook_install().
  */
 function lightning_search_install() {
+  // Search API DB is not a hard dependency, but install it if it's available so
+  // that the search index we provide will "just work" out of the box.
+  $module_data = system_rebuild_module_data();
+  if (isset($module_data['search_api_db'])) {
+    \Drupal::service('module_installer')->install(['search_api_db']);
+  }
+
   /** @var \Drupal\node\NodeTypeInterface $node_type */
   foreach (NodeType::loadMultiple() as $node_type) {
     lightning_search_node_type_insert($node_type);


### PR DESCRIPTION
As advertised. With this PR, Lightning Search will actively install Search API DB if it's available.

This addresses https://www.drupal.org/node/2855075.