### PR TITLE
Adjust the verbiage when reverting a revision

### DIFF
--- a/modules/lightning_features/lightning_workflow/src/Form/NodeRevisionRevertForm.php
+++ b/modules/lightning_features/lightning_workflow/src/Form/NodeRevisionRevertForm.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Drupal\lightning_workflow\Form;
+
+use Drupal\node\Form\NodeRevisionRevertForm as BaseForm;
+
+/**
+ * Changes verbiage in the core node revision revert form.
+ */
+class NodeRevisionRevertForm extends BaseForm {
+
+  /**
+   * Determines if the revision is a forward revision.
+   *
+   * @return bool
+   *   TRUE if the revision is a forward revision, FALSE otherwise.
+   */
+  protected function isForwardRevision() {
+    /** @var \Drupal\node\NodeInterface $node */
+    $node = $this->nodeStorage->load($this->revision->id());
+    return $this->revision->getRevisionId() > $node->getRevisionId();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion() {
+    if ($this->isForwardRevision()) {
+      $date = $this->dateFormatter->format($this->revision->getRevisionCreationTime());
+      return $this->t('Are you sure you want to switch to the revision from %revision-date?', ['%revision-date' => $date]);
+    }
+    else {
+      return parent::getQuestion();
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfirmText() {
+    return $this->isForwardRevision() ? $this->t('Switch') : parent::getConfirmText();
+  }
+
+}

--- a/modules/lightning_features/lightning_workflow/src/Routing/RouteSubscriber.php
+++ b/modules/lightning_features/lightning_workflow/src/Routing/RouteSubscriber.php
@@ -4,6 +4,7 @@ namespace Drupal\lightning_workflow\Routing;
 
 use Drupal\Core\Routing\RouteSubscriberBase;
 use Drupal\lightning_workflow\Controller\PanelizerIPEController;
+use Drupal\lightning_workflow\Form\NodeRevisionRevertForm;
 use Symfony\Component\Routing\RouteCollection;
 
 /**
@@ -18,6 +19,11 @@ class RouteSubscriber extends RouteSubscriberBase {
     $route = $collection->get('panelizer.panels_ipe.revert_to_default');
     if ($route) {
       $route->setDefault('_controller', PanelizerIPEController::class . '::revertToDefault');
+    }
+
+    $route = $collection->get('node.revision_revert_confirm');
+    if ($route) {
+      $route->setDefault('_form', NodeRevisionRevertForm::class);
     }
   }
 

--- a/tests/features/media/browser_embed_code.feature
+++ b/tests/features/media/browser_embed_code.feature
@@ -65,5 +65,7 @@ Feature: Creating media assets from within the media browser using embed codes
     When I visit "/entity-browser/iframe/media_browser"
     And I click "Create embed"
     And I enter "https://twitter.com/webchick/status/824051274353999872" for "input"
+    # The change event, which triggers AJAX, is fired after 600 milliseconds.
+    And I wait 1 second
     And I wait for AJAX to finish
     Then the "#entity" element should be empty

--- a/tests/features/media/browser_embed_code.feature
+++ b/tests/features/media/browser_embed_code.feature
@@ -53,6 +53,8 @@ Feature: Creating media assets from within the media browser using embed codes
     When I visit "/entity-browser/iframe/media_browser"
     And I click "Create embed"
     And I enter "The quick brown fox gets eaten by hungry lions." for "input"
+    # The change event, which triggers AJAX, is fired after 600 milliseconds.
+    And I wait 1 second
     And I wait for AJAX to finish
     And I press "Place"
     Then I should see the error message "No media types can be matched to this input."


### PR DESCRIPTION
Fixes https://www.drupal.org/node/2854057.

This takes a slightly advanced approach; if the target revision is a forward revision, this will say "switch" instead of "revert". Otherwise, it'll still say "revert". Didn't add tests since this is such a cosmetic change, but could do that if desired.