### PR TITLE
Provide a facade for manipulating default config

### DIFF
--- a/modules/lightning_features/lightning_core/lightning_core.install
+++ b/modules/lightning_features/lightning_core/lightning_core.install
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Entity\Entity\EntityViewMode;
+use Drupal\lightning_core\ConfigHelper as Config;
 use Drupal\node\Entity\NodeType;
 
 /**
@@ -24,12 +25,7 @@ function lightning_core_install() {
  * Creates the lightning_core settings object.
  */
 function lightning_core_update_8001() {
-  $values = lightning_core_read_config('lightning_core.settings', 'lightning_core');
-
-  \Drupal::configFactory()
-    ->getEditable('lightning_core.settings')
-    ->setData($values)
-    ->save();
+  Config::forModule('lightning_core')->get('lightning_core.settings')->save();
 }
 
 /**

--- a/modules/lightning_features/lightning_core/lightning_core.module
+++ b/modules/lightning_features/lightning_core/lightning_core.module
@@ -9,6 +9,7 @@ use Drupal\Core\Block\BlockPluginInterface;
 use Drupal\Core\Entity\EntityDescriptionInterface;
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\lightning_core\ConfigHelper as Config;
 use Drupal\lightning_core\Element as ElementHelper;
 use Drupal\lightning_core\Entity\EntityFormMode;
 use Drupal\lightning_core\Entity\EntityViewMode;
@@ -327,12 +328,10 @@ function lightning_core_preprocess_block(array &$variables) {
  *   (optional) The module which has the default configuration.
  *
  * @deprecated in Lightning 2.0.3 and will be removed in Lightning 2.1.0. Use
- * the lightning.config_helper service instead.
+ * the ConfigHelper facade instead.
  */
 function lightning_core_create_config($entity_type, $id, $module = 'lightning_core') {
-  \Drupal::service('lightning.config_helper')
-    ->install($module)
-    ->createEntity($entity_type, $id);
+  Config::forModule($module)->getEntity($entity_type, $id)->save();
 }
 
 /**
@@ -347,10 +346,8 @@ function lightning_core_create_config($entity_type, $id, $module = 'lightning_co
  *   The config data.
  *
  * @deprecated in Lightning 2.0.3 and will be removed in Lightning 2.1.0. Use
- * the lightning.config_helper service instead.
+ * the ConfigHelper facade instead.
  */
 function lightning_core_read_config($id, $module = 'lightning_core') {
-  return \Drupal::service('lightning.config_helper')
-    ->install($module)
-    ->read($id);
+  return Config::forModule($module)->read($id);
 }

--- a/modules/lightning_features/lightning_core/lightning_core.services.yml
+++ b/modules/lightning_features/lightning_core/lightning_core.services.yml
@@ -13,10 +13,12 @@ services:
       -
         name: event_subscriber
 
+  # Deprecated in Lightning 2.0.6 and will be removed in 2.1.0. Use the
+  # ConfigHelper facade instead.
   lightning.config_helper:
     class: '\Drupal\lightning_core\ConfigHelper'
     arguments:
-      - '@module_handler'
+      - '@config.factory'
       - '@entity_type.manager'
 
   lightning.display_helper:

--- a/modules/lightning_features/lightning_core/modules/lightning_dev/lightning_dev.install
+++ b/modules/lightning_features/lightning_core/modules/lightning_dev/lightning_dev.install
@@ -8,6 +8,7 @@
 use Drupal\entity_browser\Entity\EntityBrowser;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\lightning_core\ConfigHelper as Config;
 use Drupal\media_entity\Entity\MediaBundle;
 use Drupal\scheduled_updates\Entity\ScheduledUpdateType;
 use Drupal\views\Entity\View;
@@ -70,20 +71,17 @@ function lightning_dev_update_8001() {
  * Executes manual updates for Lightning 2.0.2 --> 2.0.3.
  */
 function lightning_dev_update_8002() {
-  /** @var \Drupal\lightning_core\ConfigHelper $config_helper */
-  $config_helper = \Drupal::service('lightning.config_helper')
-    ->install('lightning_landing_page')
-    ->createEntity('field_config', 'node.landing_page.body')
-    ->createEntity('entity_view_display', 'node.landing_page.teaser');
+  $config = Config::forModule('lightning_landing_page');
 
-  $values = $config_helper
-    ->read('core.entity_form_display.node.landing_page.default');
+  $config->getEntity('field_config', 'node.landing_page.body')->save();
+  $config->getEntity('entity_view_display', 'node.landing_page.teaser')->save();
+
+  $values = $config->read('core.entity_form_display.node.landing_page.default');
   entity_get_form_display('node', 'landing_page', 'default')
     ->setComponent('body', $values['content']['body'])
     ->save();
 
-  $values = $config_helper
-    ->read('core.entity_view_display.node.landing_page.default');
+  $values = $config->read('core.entity_view_display.node.landing_page.default');
   entity_get_display('node', 'landing_page', 'default')
     ->setComponent('body', $values['content']['body'])
     ->unsetThirdPartySetting('panelizer', 'enable')
@@ -117,9 +115,9 @@ function lightning_dev_update_8002() {
  */
 function lightning_dev_update_8003() {
   // Instantiate field_moderation_state on multi-node embargoes.
-  \Drupal::service('lightning.config_helper')
-    ->install('lightning_workflow')
-    ->createEntity('field_config', 'scheduled_update.multiple_node_embargo.field_moderation_state');
+  Config::forModule('lightning_workflow')
+    ->getEntity('field_config', 'scheduled_update.multiple_node_embargo.field_moderation_state')
+    ->save();
 
   // Replace field_moderation_state_1 with field_moderation_state on the
   // multi-node embargo form.

--- a/modules/lightning_features/lightning_core/modules/lightning_search/lightning_search.install
+++ b/modules/lightning_features/lightning_core/modules/lightning_search/lightning_search.install
@@ -5,6 +5,7 @@
  * Contains installation and update routines for Lightning Search.
  */
 
+use Drupal\lightning_core\ConfigHelper as Config;
 use Drupal\node\Entity\NodeType;
 use Drupal\search_api\Entity\Index;
 use Drupal\search_api\Entity\Server;
@@ -30,9 +31,10 @@ function lightning_search_install() {
   // normal site install, so create it now if it doesn't already exist.
   $server = Server::load('database');
   if (empty($server) && \Drupal::moduleHandler()->moduleExists('search_api_db')) {
-    \Drupal::service('lightning.config_helper')
-      ->optional('lightning_search')
-      ->createEntity('search_api_server', 'database');
+    Config::forModule('lightning_search')
+      ->optional()
+      ->getEntity('search_api_server', 'database')
+      ->save();
 
     $server = Server::load('database');
   }

--- a/modules/lightning_features/lightning_core/src/ConfigHelper.php
+++ b/modules/lightning_features/lightning_core/src/ConfigHelper.php
@@ -2,23 +2,31 @@
 
 namespace Drupal\lightning_core;
 
+use Drupal\Component\Utility\Unicode;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\Entity\ConfigEntityTypeInterface;
-use Drupal\Core\Config\FileStorage;
 use Drupal\Core\Config\InstallStorage;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Extension\Extension;
 
 /**
- * Helps with reading and creating default configuration.
+ * A facade to assist with manipulating default config.
  */
-class ConfigHelper {
+class ConfigHelper extends InstallStorage {
 
   /**
-   * The module handler.
+   * The extension whose default config is being manipulated by this object.
    *
-   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   * @var \Drupal\Core\Extension\Extension
    */
-  protected $moduleHandler;
+  protected $extension;
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
 
   /**
    * The entity type manager.
@@ -28,137 +36,130 @@ class ConfigHelper {
   protected $entityTypeManager;
 
   /**
-   * File storage reader for the current directory.
-   *
-   * @var FileStorage
-   */
-  protected $storage;
-
-  /**
    * ConfigHelper constructor.
    *
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   The module handler.
+   * @param \Drupal\Core\Extension\Extension $extension
+   *   The extension whose default config is being manipulated by this object.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
    */
-  public function __construct(ModuleHandlerInterface $module_handler, EntityTypeManagerInterface $entity_type_manager) {
-    $this->moduleHandler = $module_handler;
+  public function __construct(Extension $extension, ConfigFactoryInterface $config_factory, EntityTypeManagerInterface $entity_type_manager) {
+    parent::__construct();
+    $this->extension = $extension;
+    $this->configFactory = $config_factory;
     $this->entityTypeManager = $entity_type_manager;
   }
 
   /**
-   * Switches to the default config directory for a module.
-   *
-   * @param string $module
-   *   The module.
+   * Switches to the default config directory.
    *
    * @return $this
    *   The called object, for chaining.
    */
-  public function install($module) {
-    $dir = $this->moduleHandler->getModule($module)->getPath() . '/' . InstallStorage::CONFIG_INSTALL_DIRECTORY;
-    $this->storage = new FileStorage($dir);
+  public function install() {
+    $this->directory = self::CONFIG_INSTALL_DIRECTORY;
     return $this;
   }
 
   /**
-   * Switches to the optional config directory for a module.
-   *
-   * @param string $module
-   *   The module.
+   * Switches to the optional config directory.
    *
    * @return $this
    *   The called object, for chaining.
    */
-  public function optional($module) {
-    $dir = $this->moduleHandler->getModule($module)->getPath() . '/' . InstallStorage::CONFIG_OPTIONAL_DIRECTORY;
-    $this->storage = new FileStorage($dir);
+  public function optional() {
+    $this->directory = self::CONFIG_OPTIONAL_DIRECTORY;
     return $this;
   }
 
   /**
-   * Reads a config file from the current directory.
-   *
-   * @param string $id
-   *   The file to read, without the YML extension.
-   *
-   * @return mixed
-   *   The values read from the file.
-   */
-  public function read($id) {
-    return $this->storage->read($id);
-  }
-
-  /**
-   * Creates a config entity from configuration in the current directory.
-   *
-   * If an entity of the specified type with the specified ID already exists,
-   * nothing will happen.
+   * Transparently loads a config entity from the extension's config.
    *
    * @param string $entity_type
-   *   The config entity type ID.
+   *   The entity type ID.
    * @param string $id
-   *   The unprefixed entity ID.
+   *   The entity ID.
+   * @param bool $force
+   *   (optional) If TRUE, the entity is read from config even if it already
+   *   exists. Defaults to FALSE.
    *
-   * @return $this
-   *   The called object, for chaining.
+   * @return \Drupal\Core\Entity\EntityInterface|null
+   *   The config entity, or NULL if it doesn't exist.
    */
-  public function createEntity($entity_type, $id) {
-    $prefixes = $this->getConfigPrefixMap();
-
+  public function getEntity($entity_type, $id, $force = FALSE) {
     $storage = $this->entityTypeManager->getStorage($entity_type);
+    $entity = $storage->load($id);
 
-    $existing = $storage->load($id);
-    if (empty($existing)) {
-      $values = $this->read($prefixes[$entity_type] . '.' . $id);
-      if ($values) {
-        $storage->create($values)->save();
-      }
+    if ($entity && empty($force)) {
+      return $entity;
     }
-    return $this;
+    else {
+      $prefixes = $this->getConfigPrefixes();
+      $values = $this->read($prefixes[$entity_type] . '.' . $id);
+
+      return $storage->create($values);
+    }
   }
 
   /**
-   * Deletes an entity created from default configuration.
+   * Loads a simple config object from the extension's config.
    *
    * @param string $id
-   *   The configuration ID.
+   *   The config object ID.
+   *
+   * @return \Drupal\Core\Config\Config
+   *   The config object.
+   */
+  public function get($id) {
+    $data = $this->read($id);
+    return $this->configFactory->getEditable($id)->setData($data);
+  }
+
+  /**
+   * {@inheritdoc}
    */
   public function delete($id) {
-    // Get the entity type prefix map and filter it by the ID to determine what
-    // entity type this ID represents.
-    $prefixes = array_filter($this->getConfigPrefixMap(), function ($prefix) use ($id) {
-      return strpos($id, $prefix . '.') === 0;
-    });
+    foreach ($this->getConfigPrefixes() as $entity_type => $prefix) {
+      $prefix .= '.';
 
-    $entity_type = key($prefixes);
-    if ($entity_type) {
-      // Strip the prefix off the ID.
-      $id = substr($id, strlen(current($prefixes)) + 1);
-
-      $entity = $this->entityTypeManager->getStorage($entity_type)->load($id);
-      if ($entity) {
-        $entity->delete();
+      if (Unicode::strpos($id, $prefix) === 0) {
+        $entity = $this->getEntity(
+          $entity_type,
+          Unicode::substr($id, Unicode::strlen($prefix) + 1)
+        );
+        return $entity->delete();
       }
+    }
+    return $this->get($id)->delete();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function deleteAll($prefix = '') {
+    foreach ($this->listAll($prefix) as $id) {
+      $this->delete($id);
     }
   }
 
   /**
-   * Deletes all entities created from default configuration.
+   * {@inheritdoc}
    */
-  public function deleteAll() {
-    $all = $this->storage->listAll();
-    array_walk($all, [$this, 'delete']);
+  protected function getAllFolders() {
+    return $this->getComponentNames([
+      $this->extension->getName() => $this->extension,
+    ]);
   }
 
   /**
-   * Returns a map of config entity types to config prefixes.
+   * Returns a map of config entity type IDs to config prefixes.
    *
    * @return string[]
-   *   The config prefixes, keyed by their corresponding entity type ID.
+   *   The config prefixes, keyed by the corresponding entity type ID.
    */
-  protected function getConfigPrefixMap() {
+  protected function getConfigPrefixes() {
     $prefix_map = [];
 
     foreach ($this->entityTypeManager->getDefinitions() as $id => $definition) {
@@ -166,8 +167,24 @@ class ConfigHelper {
         $prefix_map[$id] = $definition->getConfigPrefix();
       }
     }
-
     return $prefix_map;
+  }
+
+  /**
+   * Creates a new ConfigHelper for a module.
+   *
+   * @param string $module
+   *   The module name.
+   *
+   * @return static
+   *   A new ConfigHelper object.
+   */
+  public static function forModule($module) {
+    return new static(
+      \Drupal::moduleHandler()->getModule($module),
+      \Drupal::configFactory(),
+      \Drupal::entityTypeManager()
+    );
   }
 
 }

--- a/modules/lightning_features/lightning_core/src/ConfigHelper.php
+++ b/modules/lightning_features/lightning_core/src/ConfigHelper.php
@@ -95,12 +95,12 @@ class ConfigHelper extends InstallStorage {
     if ($entity && empty($force)) {
       return $entity;
     }
-    else {
-      $prefixes = $this->getConfigPrefixes();
-      $values = $this->read($prefixes[$entity_type] . '.' . $id);
 
-      return $storage->create($values);
-    }
+    $prefixes = $this->getConfigPrefixes();
+
+    return $storage->create(
+      $this->read($prefixes[$entity_type] . '.' . $id)
+    );
   }
 
   /**
@@ -182,6 +182,23 @@ class ConfigHelper extends InstallStorage {
   public static function forModule($module) {
     return new static(
       \Drupal::moduleHandler()->getModule($module),
+      \Drupal::configFactory(),
+      \Drupal::entityTypeManager()
+    );
+  }
+
+  /**
+   * Creates a new ConfigHelper for a theme.
+   *
+   * @param string $theme
+   *   The theme name.
+   *
+   * @return static
+   *   A new ConfigHelper object.
+   */
+  public static function forTheme($theme) {
+    return new static(
+      \Drupal::service('theme_handler')->getTheme($theme),
       \Drupal::configFactory(),
       \Drupal::entityTypeManager()
     );

--- a/modules/lightning_features/lightning_layout/lightning_layout.install
+++ b/modules/lightning_features/lightning_layout/lightning_layout.install
@@ -5,6 +5,7 @@
  * Contains installation and update routines for Lightning Layout.
  */
 
+use Drupal\lightning_core\ConfigHelper as Config;
 use Drupal\node\Entity\NodeType;
 
 /**
@@ -30,9 +31,9 @@ function lightning_layout_update_8001() {
  * Creates the layout_manager role.
  */
 function lightning_layout_update_8002() {
-  \Drupal::service('lightning.config_helper')
-    ->install('lightning_layout')
-    ->createEntity('user_role', 'layout_manager');
+  Config::forModule('lightning_layout')
+    ->getEntity('user_role', 'layout_manager')
+    ->save();
 }
 
 /**
@@ -99,20 +100,12 @@ function lightning_layout_update_8006() {
  * Creates Lightning Layout settings config object and installs Entity Blocks.
  */
 function lightning_layout_update_8007() {
-  $id = 'lightning_layout.settings';
-
-  $values = \Drupal::service('lightning.config_helper')
-    ->install('lightning_layout')
-    ->read($id);
-
-  \Drupal::configFactory()
-    ->getEditable($id)
-    ->setData($values)
+  Config::forModule('lightning_layout')
+    ->get('lightning_layout.settings')
     ->save();
 
   \Drupal::service('module_installer')->install(['entity_block']);
 }
-
 
 /**
  * Installs the Panelizer Quick Edit module.

--- a/modules/lightning_features/lightning_media/lightning_media.install
+++ b/modules/lightning_features/lightning_media/lightning_media.install
@@ -9,7 +9,7 @@ use Drupal\editor\Entity\Editor;
 use Drupal\embed\Entity\EmbedButton;
 use Drupal\entity_browser\Entity\EntityBrowser;
 use Drupal\file\Entity\File;
-use Drupal\user\Entity\Role;
+use Drupal\lightning_core\ConfigHelper as Config;
 use Drupal\views\Entity\View;
 
 /**
@@ -77,21 +77,9 @@ function lightning_media_update_8002() {
  * Creates the Media Creator and Media Manager roles.
  */
 function lightning_media_update_8003() {
-  /** @var \Drupal\lightning_core\ConfigHelper $config */
-  $config = \Drupal::service('lightning_config_helper')
-    ->install('lightning_media');
-
-  $roles = Role::loadMultiple([
-    'media_creator',
-    'media_manager',
-  ]);
-
-  if (empty($roles['media_creator'])) {
-    $config->createEntity('user_role', 'media_creator');
-  }
-  if (empty($roles['media_manager'])) {
-    $config->createEntity('user_role', 'media_manager');
-  }
+  $config = Config::forModule('lightning_media');
+  $config->getEntity('user_role', 'media_creator')->save();
+  $config->getEntity('user_role', 'media_manager')->save();
 }
 
 /**
@@ -111,11 +99,10 @@ function lightning_media_update_8004() {
 function lightning_media_update_8005() {
   \Drupal::service('module_installer')->install(['entity_browser']);
 
-  \Drupal::service('lightning.config_helper')
-    ->install('lightning_media')
-    ->createEntity('entity_form_mode', 'media.media_browser')
-    ->createEntity('entity_browser', 'media_browser')
-    ->createEntity('embed_button', 'media_browser');
+  $config = Config::forModule('lightning_media');
+  $config->getEntity('entity_form_mode', 'media.media_browser')->save();
+  $config->getEntity('entity_browser', 'media_browser')->save();
+  $config->getEntity('embed_button', 'media_browser')->save();
 }
 
 /**
@@ -789,15 +776,9 @@ function lightning_media_update_8014() {
  * Creates the thumbnail view mode for media items.
  */
 function lightning_media_update_8015() {
-  // Only create the thumbnail view mode if it doesn't already exist.
-  $view_modes = \Drupal::service('entity_display.repository')
-    ->getViewModeOptions('media');
-
-  if (empty($view_modes['thumbnail'])) {
-    \Drupal::service('lightning.config_helper')
-      ->install('lightning_media')
-      ->createEntity('entity_view_mode', 'media.thumbnail');
-  }
+  Config::forModule('lightning_media')
+    ->getEntity('entity_view_mode', 'media.thumbnail')
+    ->save();
 }
 
 /**

--- a/modules/lightning_features/lightning_media/modules/lightning_media_document/lightning_media_document.install
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_document/lightning_media_document.install
@@ -1,15 +1,14 @@
 <?php
 
+use Drupal\lightning_core\ConfigHelper as Config;
+
 /**
  * Creates the thumbnail display for documents.
  */
 function lightning_media_document_update_8001() {
-  // Only create the thumbnail view display if it doesn't already exist.
-  if (entity_get_display('media', 'document', 'thumbnail')->isNew()) {
-    \Drupal::service('lightning.config_helper')
-      ->install('lightning_media_document')
-      ->createEntity('entity_view_display', 'media.document.thumbnail');
-  }
+  Config::forModule('lightning_media_document')
+    ->getEntity('entity_view_display', 'media.document.thumbnail')
+    ->save();
 }
 
 /**

--- a/modules/lightning_features/lightning_media/modules/lightning_media_image/lightning_media_image.install
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_image/lightning_media_image.install
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Entity\Entity\EntityFormDisplay;
 use Drupal\entity_browser\Entity\EntityBrowser;
+use Drupal\lightning_core\ConfigHelper as Config;
 use Drupal\views\Entity\View;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 
@@ -26,9 +27,9 @@ function lightning_media_image_install() {
  * Creates the media_browser form display.
  */
 function lightning_media_image_update_8001() {
-  \Drupal::service('lightning.config_helper')
-    ->install('lightning_media_image')
-    ->createEntity('entity_form_display', 'media.image.media_browser');
+  Config::forModule('lightning_media_image')
+    ->getEntity('entity_form_display', 'media.image.media_browser')
+    ->save();
 }
 
 /**
@@ -46,9 +47,9 @@ function lightning_media_image_update_8002() {
     lightning_core_rebuild_container();
   }
 
-  \Drupal::service('lightning.config_helper')
-    ->install('lightning_media_image')
-    ->createEntity('entity_browser', 'image_browser');
+  Config::forModule('lightning_media_image')
+    ->getEntity('entity_browser', 'image_browser')
+    ->save();
 }
 
 /**
@@ -599,12 +600,9 @@ function lightning_media_image_update_8005() {
  * Creates the thumbnail display for images.
  */
 function lightning_media_image_update_8006() {
-  // Only create the thumbnail view display if it doesn't already exist.
-  if (entity_get_display('media', 'image', 'thumbnail')->isNew()) {
-    \Drupal::service('lightning.config_helper')
-      ->install('lightning_media_image')
-      ->createEntity('entity_view_display', 'media.image.thumbnail');
-  }
+  Config::forModule('lightning_media_image')
+    ->getEntity('entity_view_display', 'media.image.thumbnail')
+    ->save();
 }
 
 /**

--- a/modules/lightning_features/lightning_media/modules/lightning_media_instagram/lightning_media_instagram.install
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_instagram/lightning_media_instagram.install
@@ -5,25 +5,24 @@
  * Contains install and update routines for Lightning Media Instagram.
  */
 
+use Drupal\lightning_core\ConfigHelper as Config;
+
 /**
  * Creates the media_browser form display.
  */
 function lightning_media_instagram_update_8001() {
-  \Drupal::service('lightning.config_helper')
-    ->install('lightning_media_instagram')
-    ->createEntity('entity_form_display', 'media.instagram.media_browser');
+  Config::forModule('lightning_media_instagram')
+    ->getEntity('entity_form_display', 'media.instagram.media_browser')
+    ->save();
 }
 
 /**
  * Creates the thumbnail display for Instagram posts.
  */
 function lightning_media_instagram_update_8002() {
-  // Only create the thumbnail view display if it doesn't already exist.
-  if (entity_get_display('media', 'instagram', 'thumbnail')->isNew()) {
-    \Drupal::service('lightning.config_helper')
-      ->install('lightning_media_instagram')
-      ->createEntity('entity_view_display', 'media.instagram.thumbnail');
-  }
+  Config::forModule('lightning_media_instagram')
+    ->getEntity('entity_view_display', 'media.instagram.thumbnail')
+    ->save();
 }
 
 /**

--- a/modules/lightning_features/lightning_media/modules/lightning_media_twitter/lightning_media_twitter.install
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_twitter/lightning_media_twitter.install
@@ -5,25 +5,24 @@
  * Contains install and update routines for Lightning Media Twitter.
  */
 
+use Drupal\lightning_core\ConfigHelper as Config;
+
 /**
  * Creates the media_browser form display.
  */
 function lightning_media_twitter_update_8001() {
-  \Drupal::service('lightning.config_helper')
-    ->install('lightning_media_twitter')
-    ->createEntity('entity_form_display', 'media.tweet.media_browser');
+  Config::forModule('lightning_media_twitter')
+    ->getEntity('entity_form_display', 'media.tweet.media_browser')
+    ->save();
 }
 
 /**
  * Creates the thumbnail display for tweets.
  */
 function lightning_media_twitter_update_8002() {
-  // Only create the thumbnail view display if it doesn't already exist.
-  if (entity_get_display('media', 'tweet', 'thumbnail')->isNew()) {
-    \Drupal::service('lightning.config_helper')
-      ->install('lightning_media_twitter')
-      ->createEntity('entity_view_display', 'media.tweet.thumbnail');
-  }
+  Config::forModule('lightning_media_twitter')
+    ->getEntity('entity_view_display', 'media.tweet.thumbnail')
+    ->save();
 }
 
 /**
@@ -40,4 +39,3 @@ function lightning_media_twitter_update_dependencies() {
     ],
   ];
 }
-

--- a/modules/lightning_features/lightning_media/modules/lightning_media_video/lightning_media_video.install
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_video/lightning_media_video.install
@@ -8,6 +8,7 @@
 use Drupal\Core\Entity\Entity\EntityFormDisplay;
 use Drupal\Core\Entity\Entity\EntityViewDisplay;
 use Drupal\field\Entity\FieldConfig;
+use Drupal\lightning_core\ConfigHelper as Config;
 use Drupal\media_entity\Entity\MediaBundle;
 use Drupal\video_embed_media\Plugin\MediaEntity\Type\VideoEmbedField;
 
@@ -78,21 +79,18 @@ function lightning_media_video_update_8001() {
  * Creates the media_browser form display.
  */
 function lightning_media_video_update_8002() {
-  \Drupal::service('lightning.config_helper')
-    ->install('lightning_media_video')
-    ->createEntity('entity_form_display', 'media.video.media_browser');
+  Config::forModule('lightning_media_video')
+    ->getEntity('entity_form_display', 'media.video.media_browser')
+    ->save();
 }
 
 /**
  * Creates the thumbnail display for videos.
  */
 function lightning_media_video_update_8003() {
-  // Only create the thumbnail view display if it doesn't already exist.
-  if (entity_get_display('media', 'video', 'thumbnail')->isNew()) {
-    \Drupal::service('lightning.config_helper')
-      ->install('lightning_media_video')
-      ->createEntity('entity_view_display', 'media.video.thumbnail');
-  }
+  Config::forModule('lightning_media_video')
+    ->getEntity('entity_view_display', 'media.video.thumbnail')
+    ->save();
 }
 
 /**


### PR DESCRIPTION
This is purely a DX improvement for Lightning, but it opens the door to smoothing out the complex config manipulation that will be involved in splitting the automatic role functionality into its own sub-component.

We used to have functions, like lightning_core_read_config(). Then we moved that stuff into the lightning.config_helper service. This PR makes ConfigHelper extend the core InstallStorage class, which allows it to become a smooth facade around a module's default config, like so:

```php
ConfigHelper::forModule('lightning_core')->getEntity('field_storage_config', 'node.field_meta_tags')
```

This will load the node.field_meta_tags field storage config entity, if it exists -- otherwise it will read it from Lightning Core's default config and return an unsaved entity object, all transparent to the calling code.

It also works for optional config:

```php
ConfigHelper::forModule('lightning_search')->optional()->getEntity('search_api_server', 'database')
```

And it works for simple config (non-entities) as well, except it returns simple config objects rather than entities:

```php
ConfigHelper::forModule('lightning_core')->get('lightning_core.settings')->save()
```