### PR TITLE
Start adding PHPUnit tests

### DIFF
--- a/modules/lightning_features/lightning_core/tests/src/Kernel/Access/AdministrativeRoleCheckTest.php
+++ b/modules/lightning_features/lightning_core/tests/src/Kernel/Access/AdministrativeRoleCheckTest.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\Tests\lightning_core\Kernel\Access;
 
-use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Routing\RouteMatch;
 use Drupal\lightning_core\Access\AdministrativeRoleCheck;
 use Drupal\Tests\token\Kernel\KernelTestBase;
 use Drupal\user\Entity\Role;
@@ -34,13 +34,8 @@ class AdministrativeRoleCheckTest extends KernelTestBase {
       'is_admin' => TRUE,
     ])->save();
 
-    $route = $this
-      ->prophesize(Route::class)
-      ->reveal();
-
-    $route_match = $this
-      ->prophesize(RouteMatchInterface::class)
-      ->reveal();
+    $route = new Route('/foo');
+    $route_match = new RouteMatch('foo', $route);
 
     $account = User::create();
     $account->addRole($admin_role);

--- a/modules/lightning_features/lightning_core/tests/src/Kernel/Access/AdministrativeRoleCheckTest.php
+++ b/modules/lightning_features/lightning_core/tests/src/Kernel/Access/AdministrativeRoleCheckTest.php
@@ -3,8 +3,8 @@
 namespace Drupal\Tests\lightning_core\Kernel\Access;
 
 use Drupal\Core\Routing\RouteMatch;
+use Drupal\KernelTests\KernelTestBase;
 use Drupal\lightning_core\Access\AdministrativeRoleCheck;
-use Drupal\Tests\token\Kernel\KernelTestBase;
 use Drupal\user\Entity\Role;
 use Drupal\user\Entity\User;
 use Symfony\Component\Routing\Route;

--- a/modules/lightning_features/lightning_core/tests/src/Kernel/Access/AdministrativeRoleCheckTest.php
+++ b/modules/lightning_features/lightning_core/tests/src/Kernel/Access/AdministrativeRoleCheckTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Drupal\Tests\lightning_core\Kernel\Access;
+
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\lightning_core\Access\AdministrativeRoleCheck;
+use Drupal\Tests\token\Kernel\KernelTestBase;
+use Drupal\user\Entity\Role;
+use Drupal\user\Entity\User;
+use Symfony\Component\Routing\Route;
+
+/**
+ * @coversDefaultClass \Drupal\lightning_core\Access\AdministrativeRoleCheck
+ *
+ * @group lightning
+ * @group lightning_core
+ */
+class AdministrativeRoleCheckTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = ['user'];
+
+  /**
+   * @covers ::access
+   */
+  public function testAccess() {
+    $admin_role = $this->randomMachineName();
+
+    Role::create([
+      'id' => $admin_role,
+      'label' => $admin_role,
+      'is_admin' => TRUE,
+    ])->save();
+
+    $route = $this
+      ->prophesize(Route::class)
+      ->reveal();
+
+    $route_match = $this
+      ->prophesize(RouteMatchInterface::class)
+      ->reveal();
+
+    $account = User::create();
+    $account->addRole($admin_role);
+
+    $access_check = new AdministrativeRoleCheck(
+      $this->container->get('entity_type.manager')
+    );
+
+    $this->assertTrue($access_check->access($route, $route_match, $account)->isAllowed());
+
+    $account->removeRole($admin_role);
+    $this->assertTrue($access_check->access($route, $route_match, $account)->isForbidden());
+  }
+
+}

--- a/modules/lightning_features/lightning_core/tests/src/Kernel/Access/AdministrativeRoleCheckTest.php
+++ b/modules/lightning_features/lightning_core/tests/src/Kernel/Access/AdministrativeRoleCheckTest.php
@@ -20,7 +20,7 @@ class AdministrativeRoleCheckTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = ['user'];
+  public static $modules = ['system', 'user'];
 
   /**
    * @covers ::access

--- a/modules/lightning_features/lightning_core/tests/src/Kernel/ElementTest.php
+++ b/modules/lightning_features/lightning_core/tests/src/Kernel/ElementTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Drupal\Tests\lightning_core\Kernel;
+
+use Drupal\lightning_core\Element;
+use Drupal\Tests\token\Kernel\KernelTestBase;
+
+/**
+ * @coversDefaultClass \Drupal\lightning_core\Element
+ *
+ * @group lightning
+ * @group lightning_core
+ */
+class ElementTest extends KernelTestBase {
+
+  /**
+   * @covers ::oxford
+   */
+  public function testOxford() {
+    $this->assertEmpty(
+      Element::oxford([])
+    );
+    $this->assertEquals(
+      'fettucine',
+      Element::oxford(['fettucine'])
+    );
+    $this->assertEquals(
+      'fettucine and linguine',
+      Element::oxford(['fettucine', 'linguine'])
+    );
+    $this->assertEquals(
+      'fettucine, linguine, and ravioli',
+      Element::oxford(['fettucine', 'linguine', 'ravioli'])
+    );
+  }
+
+  /**
+   * @covers ::processLegend
+   */
+  public function testProcessLegendArray() {
+    $element = [
+      'foo' => [
+        '#type' => 'checkbox',
+      ],
+      'bar' => [
+        '#type' => 'checkbox',
+      ],
+      'baz' => [
+        '#type' => 'checkbox',
+      ],
+      '#legend' => [
+        'foo' => 'Foo',
+        'bar' => 'Bar',
+        'baz' => 'Baz',
+        'blorf' => 'Blorf',
+      ],
+    ];
+    $element = Element::processLegend($element);
+    $this->assertEquals('Foo', $element['foo']['#description']);
+    $this->assertEquals('Bar', $element['bar']['#description']);
+    $this->assertEquals('Baz', $element['baz']['#description']);
+    $this->assertArrayNotHasKey('blorf', $element);
+  }
+
+  /**
+   * @covers ::processLegend
+   */
+  public function testProcessLegendCallable() {
+    $legend = function (array $item) {
+      return ucfirst($item['#label']);
+    };
+
+    $element = [
+      'foo' => [
+        '#type' => 'checkbox',
+        '#label' => 'foo',
+      ],
+      'bar' => [
+        '#type' => 'checkbox',
+        '#label' => 'bar',
+      ],
+      'baz' => [
+        '#type' => 'checkbox',
+        '#label' => 'baz',
+      ],
+      '#legend' => $legend,
+    ];
+    $element = Element::processLegend($element);
+    $this->assertEquals('Foo', $element['foo']['#description']);
+    $this->assertEquals('Bar', $element['bar']['#description']);
+    $this->assertEquals('Baz', $element['baz']['#description']);
+  }
+
+}

--- a/modules/lightning_features/lightning_core/tests/src/Kernel/ElementTest.php
+++ b/modules/lightning_features/lightning_core/tests/src/Kernel/ElementTest.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\Tests\lightning_core\Kernel;
 
+use Drupal\KernelTests\KernelTestBase;
 use Drupal\lightning_core\Element;
-use Drupal\Tests\token\Kernel\KernelTestBase;
 
 /**
  * @coversDefaultClass \Drupal\lightning_core\Element

--- a/modules/lightning_features/lightning_core/tests/src/Kernel/EntityDescriptionTest.php
+++ b/modules/lightning_features/lightning_core/tests/src/Kernel/EntityDescriptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Drupal\Tests\lightning_core\Kernel;
+
+use Drupal\Core\Entity\EntityDescriptionInterface;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * @group lightning
+ * @group lightning_core
+ */
+class EntityDescriptionTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = ['lightning_core', 'user'];
+
+  /**
+   * Data provider for ::testEntityDescription().
+   *
+   * @return array
+   *   The test data.
+   */
+  public function provider() {
+    return [
+      ['entity_form_mode'],
+      ['entity_view_mode'],
+      ['user_role'],
+    ];
+  }
+
+  /**
+   * Tests entity description functionality for an entity type.
+   *
+   * @param string $entity_type_id
+   *   The entity type ID.
+   * @param array $values
+   *   (optional) Values with which to create the entity.
+   *
+   * @dataProvider provider
+   */
+  public function testEntityDescription($entity_type_id, array $values = []) {
+    $entity = $this->container
+      ->get('entity_type.manager')
+      ->getStorage($entity_type_id)
+      ->create($values);
+
+    $this->assertInstanceOf(EntityDescriptionInterface::class, $entity);
+    /** @var \Drupal\Core\Entity\EntityDescriptionInterface $entity */
+    $this->assertEmpty($entity->getDescription());
+    $description = $this->randomString(32);
+    $entity->setDescription($description);
+    $this->assertEquals($description, $entity->getDescription());
+  }
+
+}

--- a/modules/lightning_features/lightning_core/tests/src/Unit/DisplayHelperTest.php
+++ b/modules/lightning_features/lightning_core/tests/src/Unit/DisplayHelperTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Drupal\Tests\lightning_core\Unit\DisplayHelperTest;
+
+use Drupal\Core\Entity\Display\EntityDisplayInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\Query\QueryFactory;
+use Drupal\lightning_core\DisplayHelper;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * @coversDefaultClass \Drupal\lightning_core\DisplayHelper
+ *
+ * @group lightning
+ * @group lightning_core
+ */
+class DisplayHelperTest extends UnitTestCase {
+
+  /**
+   * @covers ::getNewComponents
+   */
+  public function testNewComponents() {
+    /** @var \Drupal\Core\Entity\Display\EntityDisplayInterface|\Prophecy\Prophecy\ProphecyInterface $display */
+    $display = $this->prophesize(EntityDisplayInterface::class);
+    $display->getComponents()->willReturn([
+      'foo' => [
+        'type' => 'fubar',
+      ],
+      'bar' => [
+        'type' => 'pastafazoul',
+      ],
+    ]);
+
+    /** @var \Drupal\Core\Entity\Display\EntityDisplayInterface|\Prophecy\Prophecy\ProphecyInterface $original */
+    $original = $this->prophesize(EntityDisplayInterface::class);
+    $original->getComponents()->willReturn([
+      'foo' => [
+        'type' => 'fubar',
+      ],
+    ]);
+
+    $display = $display->reveal();
+    $display->original = $original->reveal();
+
+    $helper = new DisplayHelper(
+      $this->prophesize(QueryFactory::class)->reveal(),
+      $this->prophesize(EntityFieldManagerInterface::class)->reveal()
+    );
+
+    $components = $helper->getNewComponents($display);
+    $this->assertArrayHasKey('bar', $components);
+    $this->assertArrayNotHasKey('foo', $components);
+  }
+
+}

--- a/modules/lightning_features/lightning_preview/tests/src/Unit/WorkspaceLockTest.php
+++ b/modules/lightning_features/lightning_preview/tests/src/Unit/WorkspaceLockTest.php
@@ -14,6 +14,8 @@ use Prophecy\Argument;
 
 /**
  * @coversDefaultClass \Drupal\lightning_preview\WorkspaceLock
+ *
+ * @group lightning
  * @group lightning_preview
  */
 class WorkspaceLockTest extends UnitTestCase {


### PR DESCRIPTION
Now that we have PHPUnit support, I have written a few tests that take advantage of it. Mostly simple tests of helper classes and other relatively minor bolt-on functionality.

Basically, this PR adds test coverage. Never a bad thing :)