### PR TITLE
Verified that Lightning Roles is enabled before attempting Media Image role setup

### DIFF
--- a/modules/lightning_features/lightning_media/modules/lightning_media_image/lightning_media_image.install
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_image/lightning_media_image.install
@@ -20,7 +20,9 @@ function lightning_media_image_install() {
 
   // Grants image browser access to the creator content role and the
   // media_creator and media_manager roles.
-  lightning_media_image_update_8004();
+  if (\Drupal::moduleHandler()->moduleExists('lightning_roles')) {
+    lightning_media_image_modules_installed(['lightning_roles']);
+  }
 }
 
 /**
@@ -562,18 +564,14 @@ function lightning_media_image_update_8003() {
 }
 
 /**
- * Grants image browser access to media_creator role and creator content role.
+ * Removed in Lightning 8.x-2.07.
+ *
+ * Formerly added the 'access image_browser entity browser pages' permission to
+ * the media_creator, media_manager and creator content roles.
+ *
+ * @deprecated
  */
 function lightning_media_image_update_8004() {
-  $permissions = ['access image_browser entity browser pages'];
-
-  // Media creators and managers can always access the image browser.
-  user_role_grant_permissions('media_creator', $permissions);
-  user_role_grant_permissions('media_manager', $permissions);
-
-  // Any content creator can as well.
-  \Drupal::service('lightning.content_roles')
-    ->grantPermissions('creator', $permissions);
 }
 
 /**

--- a/modules/lightning_features/lightning_media/modules/lightning_media_image/lightning_media_image.install
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_image/lightning_media_image.install
@@ -564,10 +564,11 @@ function lightning_media_image_update_8003() {
 }
 
 /**
- * Removed in Lightning 8.x-2.07.
+ * Removed in Lightning 8.x-2.10.
  *
  * Formerly added the 'access image_browser entity browser pages' permission to
- * the media_creator, media_manager and creator content roles.
+ * the media_creator and media_manager roles, as well as the creator content
+ * role.
  *
  * @deprecated
  */

--- a/modules/lightning_features/lightning_media/modules/lightning_media_image/lightning_media_image.module
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_image/lightning_media_image.module
@@ -16,16 +16,15 @@ use Drupal\lightning_media_image\Plugin\MediaEntity\Type\Image;
  */
 function lightning_media_image_modules_installed(array $modules) {
   if (in_array('lightning_roles', $modules)) {
+    $permissions = ['access image_browser entity browser pages'];
+
+    // Media creators and managers can always access the image browser.
+    user_role_grant_permissions('media_creator', $permissions);
+    user_role_grant_permissions('media_manager', $permissions);
+
+    // Any content creator can as well.
     \Drupal::service('lightning.content_roles')
-      ->grantPermissions('media_creator', [
-        'access image_browser entity browser pages',
-      ])
-      ->grantPermissions('media_manager', [
-        'access image_browser entity browser pages',
-      ])
-      ->grantPermissions('creator', [
-        'access image_browser entity browser pages',
-      ]);
+      ->grantPermissions('creator', $permissions);
   }
 }
 

--- a/modules/lightning_features/lightning_media/modules/lightning_media_image/lightning_media_image.module
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_image/lightning_media_image.module
@@ -12,6 +12,24 @@ use Drupal\lightning_core\OverrideHelper as Override;
 use Drupal\lightning_media_image\Plugin\MediaEntity\Type\Image;
 
 /**
+ * Implements hook_modules_installed().
+ */
+function lightning_media_image_modules_installed(array $modules) {
+  if (in_array('lightning_roles', $modules)) {
+    \Drupal::service('lightning.content_roles')
+      ->grantPermissions('media_creator', [
+        'access image_browser entity browser pages',
+      ])
+      ->grantPermissions('media_manager', [
+        'access image_browser entity browser pages',
+      ])
+      ->grantPermissions('creator', [
+        'access image_browser entity browser pages',
+      ]);
+  }
+}
+
+/**
  * Implements hook_media_entity_type_info_alter().
  */
 function lightning_media_image_media_entity_type_info_alter(array &$types) {


### PR DESCRIPTION
After updating a profile which extends Lightning, I started seeing errors when installing Lightning Media Image.

In hook_install(), Lightning Media Image attempts to grant the 'media_creator' and 'media_manager' roles the 'access image_browser entity browser pages' permission. However, those roles may not be available as they are optional config which depends on the Lightning Roles module being installed.

It looks like changes were made to the Media, Layout and Workflow modules to accommodate the addition of the Lightning Roles module (which is great btw!), so I made similar changes to Lightning Media Image.