### PR TITLE
Lightning Core has undeclared dependency on field_ui

### DIFF
--- a/modules/lightning_features/lightning_core/lightning_core.info.yml
+++ b/modules/lightning_features/lightning_core/lightning_core.info.yml
@@ -5,6 +5,7 @@ package: Lightning
 description: 'Shared functionality for the Lightning distribution.'
 version: '8.x-2.x-dev'
 dependencies:
+  - field_ui
   - menu_ui
   - metatag
   - node


### PR DESCRIPTION
If you disable field_ui, you'll get a class not found exception thrown by a class in lightning_core: https://github.com/acquia/lightning/blob/8.x-2.x/modules/lightning_features/lightning_core/src/Form/EntityDisplayModeAddForm.php

At a minimum, this dependency should be declared to avoid a fatal error, which is what this PR does.

However, long-term I think this dependency should be eliminated, since best practice is typically to disable Field UI in production environments.

Note that while field_ui _is_ a declared dependency of the parent Lightning profile, this is no longer adequate protection since sub-profiles can exclude it.