### PR TITLE
Randomize user 1 name on install

### DIFF
--- a/lightning.install
+++ b/lightning.install
@@ -33,6 +33,7 @@ function lightning_install() {
   // Assign user 1 the "administrator" role.
   $user = User::load(1);
   $user->roles[] = 'administrator';
+  $user->setUsername(uniqid('admin-'));
   $user->save();
 
   // Allow authenticated users to use shortcuts.


### PR DESCRIPTION
It's best practice to not use the default "admin" username for user 1, since that's the first thing brute-force attackers will attempt to use. All projects should change this eventually, so let's just automate it and get projects off on the right foot.