### PR TITLE
Make empty layout regions visible

### DIFF
--- a/modules/lightning_features/lightning_layout/css/ipe.css
+++ b/modules/lightning_features/lightning_layout/css/ipe.css
@@ -1,0 +1,8 @@
+#panels-ipe-content [data-region-name] [data-droppable-region-name]:empty {
+    min-height: 10em;
+    background-color: #eee;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    display: block;
+}

--- a/modules/lightning_features/lightning_layout/lightning_layout.module
+++ b/modules/lightning_features/lightning_layout/lightning_layout.module
@@ -18,6 +18,19 @@ use Drupal\user\Entity\Role;
 use Drupal\user\RoleInterface;
 
 /**
+ * Implements hook_library_info_alter().
+ */
+function lightning_layout_library_info_alter(array &$libraries, $extension) {
+  if ($extension == 'panels_ipe') {
+    $css = sprintf(
+      '/%s/css/ipe.css',
+      \Drupal::moduleHandler()->getModule('lightning_layout')->getPath()
+    );
+    $libraries['panels_ipe']['css']['component'][$css] = [];
+  }
+}
+
+/**
  * Implements hook_modules_installed().
  */
 function lightning_layout_modules_installed(array $modules) {


### PR DESCRIPTION
This fixes an issue mentioned in our backlog, #180.

Right now, when using Panels IPE, if you are editing a layout that contains any empty regions, the empty regions display a title bar and nothing else. I think this is kinda icky, and it gives very little sense of what the layout looks like, or that the empty regions are buckets into which things may be placed.

This PR adds a bit of CSS to Panels IPE so that empty regions will be displayed as empty grey boxes when the layout is being edited. It looks, like, 1,000 times nicer (IMHO).