### PR TITLE
ModerationAwareEntityFormTrait is not very smart

### DIFF
--- a/modules/lightning_features/lightning_workflow/src/Form/NodeForm.php
+++ b/modules/lightning_features/lightning_workflow/src/Form/NodeForm.php
@@ -34,17 +34,18 @@ class NodeForm extends BaseNodeForm {
   protected function actions(array $form, FormStateInterface $form_state) {
     $element = parent::actions($form, $form_state);
 
-    // Show the basic 'Save' button.
-    $element['submit']['#access'] = TRUE;
+    if ($this->moderationInfo()->isModeratedEntityForm($this)) {
+      // Show the basic 'Save' button.
+      $element['submit']['#access'] = TRUE;
 
-    // Hide the 'Save and publish' button.
-    $element['publish']['#access'] = FALSE;
-    unset($element['publish']['#dropbutton']);
+      // Hide the 'Save and publish' button.
+      $element['publish']['#access'] = FALSE;
+      unset($element['publish']['#dropbutton']);
 
-    // Hide the 'Save as unpublished' button.
-    $element['unpublish']['#access'] = FALSE;
-    unset($element['unpublish']['#dropbutton']);
-
+      // Hide the 'Save as unpublished' button.
+      $element['unpublish']['#access'] = FALSE;
+      unset($element['unpublish']['#dropbutton']);
+    }
     return $element;
   }
 

--- a/tests/features/workflow/moderation_states.feature
+++ b/tests/features/workflow/moderation_states.feature
@@ -83,7 +83,7 @@ Feature: Workflow moderation states
     Then I should see a "system_main_block" block with a "quickedit" contextual link
 
   @35d54919
-  Scenario: Content whose content type is not moderated is visible in the Content view
+  Scenario: Unmoderated content types are visible in the Content view
     Given node_type entities:
       | type          | name          |
       | not_moderated | Not Moderated |
@@ -93,3 +93,13 @@ Feature: Workflow moderation states
     And I am logged in as a user with the administrator role
     When I visit "admin/content"
     Then I should see "Lazy Lummox"
+
+  @d0f9aaa8
+  Scenario: Unmoderated content types have normal submit buttons
+    Given node_type entities:
+      | type          | name          |
+      | not_moderated | Not Moderated |
+    And I am logged in as a user with the "administer nodes,create not_moderated content" permissions
+    When I visit "/node/add/not_moderated"
+    Then I should see the "Save and publish" button
+    And I should see the "Save as unpublished" button


### PR DESCRIPTION
This PR addresses https://www.drupal.org/node/2867465.

In a nutshell, the problem is that our NodeForm::actions() method doesn't bother to check if the entity being worked on is, in fact, moderatable. So it goes and mucks with the buttons even if it shouldn't. This adds a check to prevent that, plus a regression test.