### PR TITLE
Show the bundle filter if the contextual filter value is an exception

### DIFF
--- a/modules/lightning_features/lightning_core/src/YieldToArgumentTrait.php
+++ b/modules/lightning_features/lightning_core/src/YieldToArgumentTrait.php
@@ -28,7 +28,7 @@ trait YieldToArgumentTrait {
     $value = $argument->getValue();
 
     $key = $this->options['expose']['identifier'];
-    $form[$key]['#access'] = is_null($value);
+    $form[$key]['#access'] = is_null($value) || $argument->isException($value);
   }
 
   /**


### PR DESCRIPTION
In \Drupal\lightning_core\YieldToArgumentTrait, the "bundle" exposed filter is hidden if the contextual filter it yields to has a value. As the Media View is configured to have a fallback value ("all") for its contextual filter, it always appears as if that argument has a value. We should add an extra check in YieldToArgumentTrait that shows the exposed filter if the argument it yields to is returning a value that equals its "exception" value (i.e. the value that shows all results if present, "all").

This resolves #351.