### PR TITLE
Allow release numbers to be larger than 9

### DIFF
--- a/src/Composer/Package.php
+++ b/src/Composer/Package.php
@@ -72,9 +72,9 @@ class Package {
     foreach ($make['projects'] as $key => &$project) {
       if ($project['download']['type'] == 'git') {
         $tag = $project['download']['tag'];
-        preg_match('/[0-9]\.x-[0-9]\.0/', $tag, $match);
+        preg_match('/\d+\.x-\d+\.0/', $tag, $match);
         $tag = str_replace($match, str_replace('x-', NULL, $match), $tag);
-        preg_match('/[0-9]\.[0-9]\.0/', $tag, $match);
+        preg_match('/\d+\.\d+\.0/', $tag, $match);
         $tag = str_replace($match, substr($match[0], 0, -2), $tag);
         $project['version'] = $tag;
         unset($project['download']);


### PR DESCRIPTION
Acquia connector just released 8.x-1.10. Our package script's regex checks for a single integer (0-9) in that location so it noped out after running composer update. This PR just loosens the current 0-9 constraints to accept any integer.