### PR TITLE
Update FileUpload.php

### DIFF
--- a/modules/lightning_features/lightning_media/src/Plugin/EntityBrowser/Widget/FileUpload.php
+++ b/modules/lightning_features/lightning_media/src/Plugin/EntityBrowser/Widget/FileUpload.php
@@ -104,8 +104,8 @@ class FileUpload extends EntityFormProxy {
       $entity,
       MediaHelper::getSourceField($entity)->entity
     );
-    $file->setPermanent();
-    $file->save();
+    //$file->setPermanent();
+    //$file->save();
     $entity->save();
 
     $selection = [


### PR DESCRIPTION
The $file->setPermanent() is already call when you use the file in media entity. If you call this function at this point you can't use tokens or filefield_paths to manipulate the image name and folder to be saved.

#357 You can see the problem with filefield_paths