### PR TITLE
"Create new revision" checkbox hidden for nodes that are not using workbench moderation

### DIFF
--- a/modules/lightning_features/lightning_workflow/src/Form/NodeForm.php
+++ b/modules/lightning_features/lightning_workflow/src/Form/NodeForm.php
@@ -20,10 +20,12 @@ class NodeForm extends BaseNodeForm {
   public function form(array $form, FormStateInterface $form_state) {
     $form = $this->traitForm($form, $form_state);
 
-    // Workbench Moderation enforces revisions by checking and disabling the
-    // revision checkbox. We don't need to display that.
-    $form['revision']['#type'] = 'hidden';
-    unset($form['revision_log']['#states']['visible'][':input[name="revision"]']);
+    if ($this->moderationInfo()->isModeratedEntityForm($this)) {
+      // Workbench Moderation enforces revisions by checking and disabling the
+      // revision checkbox. We don't need to display that.
+      $form['revision']['#type'] = 'hidden';
+      unset($form['revision_log']['#states']['visible'][':input[name="revision"]']);
+    }
 
     return $form;
   }

--- a/tests/features/workflow/moderation_states.feature
+++ b/tests/features/workflow/moderation_states.feature
@@ -116,3 +116,4 @@ Feature: Workflow moderation states
     When I visit "/deft-zebra"
     And I click "Edit"
     Then I should see "Create new revision"
+    

--- a/tests/features/workflow/moderation_states.feature
+++ b/tests/features/workflow/moderation_states.feature
@@ -103,3 +103,16 @@ Feature: Workflow moderation states
     When I visit "/node/add/not_moderated"
     Then I should see the "Save and publish" button
     And I should see the "Save as unpublished" button
+
+  @7cef449b
+  Scenario: Unmoderated content types have the "Create new revision" Checkbox
+    Given node_type entities:
+      | type          | name          |
+      | not_moderated | Not Moderated |
+    And not_moderated content:
+      | title       | path       |
+      | Deft Zebra  | /deft-zebra |
+    And I am logged in as a user with the administrator role
+    When I visit "/deft-zebra"
+    And I click "Edit"
+    Then I should see "Create new revision"


### PR DESCRIPTION
See D.O https://www.drupal.org/node/2876698. Added test.