### PR TITLE
Fixed stale configuration exports.

### DIFF
--- a/modules/lightning_features/lightning_media/config/install/entity_browser.browser.media_browser.yml
+++ b/modules/lightning_features/lightning_media/config/install/entity_browser.browser.media_browser.yml
@@ -1,6 +1,8 @@
 langcode: en
 status: true
 dependencies:
+  config:
+    - views.view.media
   module:
     - lightning_media
     - views
@@ -8,11 +10,11 @@ name: media_browser
 label: 'Media browser'
 display: iframe
 display_configuration:
-  path: /media-browser
   width: 100%
   height: '640'
   link_text: 'Select entities'
   auto_open: true
+  path: /media-browser
 selection_display: no_display
 selection_display_configuration: {  }
 widget_selector: tabs
@@ -20,9 +22,10 @@ widget_selector_configuration: {  }
 widgets:
   134808d9-d854-4a0b-8699-d5eba006b8b7:
     settings:
-      submit_text: Place
       view: media
       view_display: entity_browser_1
+      submit_text: Place
+      auto_select: false
     uuid: 134808d9-d854-4a0b-8699-d5eba006b8b7
     weight: -10
     label: Library
@@ -30,6 +33,7 @@ widgets:
   8b142f33-59d1-47b1-9e3a-4ae85d8376fa:
     settings:
       submit_text: Place
+      form_mode: media_browser
     uuid: 8b142f33-59d1-47b1-9e3a-4ae85d8376fa
     weight: -8
     label: 'Create embed'
@@ -37,6 +41,7 @@ widgets:
   044d2af7-314b-4830-8b6d-64896bbb861e:
     settings:
       submit_text: Place
+      form_mode: media_browser
     uuid: 044d2af7-314b-4830-8b6d-64896bbb861e
     weight: -9
     label: Upload

--- a/modules/lightning_features/lightning_media/modules/lightning_media_image/config/install/entity_browser.browser.image_browser.yml
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_image/config/install/entity_browser.browser.image_browser.yml
@@ -1,6 +1,8 @@
 langcode: en
 status: true
 dependencies:
+  config:
+    - views.view.media
   module:
     - lightning_media
     - views
@@ -20,6 +22,7 @@ widgets:
   44d52e51-9627-43b5-a637-3b0462041d1c:
     settings:
       submit_text: Select
+      form_mode: media_browser
       return_file: true
     uuid: 44d52e51-9627-43b5-a637-3b0462041d1c
     weight: -9
@@ -30,6 +33,7 @@ widgets:
       view: media
       view_display: image_browser
       submit_text: Select
+      auto_select: false
     uuid: 58383135-0f34-4a4a-85fc-5cf9b5de2fdd
     weight: -10
     label: Library

--- a/modules/lightning_features/lightning_media/modules/lightning_media_twitter/config/install/media_entity.bundle.tweet.yml
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_twitter/config/install/media_entity.bundle.tweet.yml
@@ -12,6 +12,7 @@ type: twitter
 type_configuration:
   source_field: embed_code
   use_twitter_api: false
+  generate_thumbnails: false
   consumer_key: ''
   consumer_secret: ''
   oauth_access_token: ''


### PR DESCRIPTION
At some point, the Entity Browser and Media modules were updated, and these updates brought with them some config schema changes. However, these schema changes were never captured in Lightning's exported configuration.

For instance, Entity Browser added an [auto_select setting](https://www.drupal.org/node/2822009) in 1.0-beta4, but when Lightning updated Entity Browser to 1.0-beta4 it didn't re-export the Entity Browser config to capture this change.

In the future, it's important when updating modules to follow a process such as the one [suggested by BLT](http://blt.readthedocs.io/en/stable/readme/configuration-management/#updating-core-and-contributed-modules) to capture configuration changes. I think these are relatively harmless but it could cause more serious and hard to diagnose problems.