### PR TITLE
Add content region to all entity form/view displays

### DIFF
--- a/config/install/core.entity_form_display.block_content.basic.default.yml
+++ b/config/install/core.entity_form_display.block_content.basic.default.yml
@@ -19,6 +19,7 @@ content:
       summary_rows: 3
       placeholder: ''
     third_party_settings: {  }
+    region: content
   info:
     type: string_textfield
     weight: -5
@@ -26,4 +27,5 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+    region: content
 hidden: {  }

--- a/config/install/core.entity_view_display.block_content.basic.default.yml
+++ b/config/install/core.entity_view_display.block_content.basic.default.yml
@@ -17,4 +17,5 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
+    region: content
 hidden: {  }

--- a/modules/lightning_features/lightning_core/modules/lightning_page/config/install/core.entity_form_display.node.page.default.yml
+++ b/modules/lightning_features/lightning_core/modules/lightning_page/config/install/core.entity_form_display.node.page.default.yml
@@ -21,6 +21,7 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+    region: content
   uid:
     type: entity_reference_autocomplete
     weight: 1
@@ -29,28 +30,33 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+    region: content
   created:
     type: datetime_timestamp
     weight: 2
     settings: {  }
     third_party_settings: {  }
+    region: content
   promote:
     type: boolean_checkbox
     settings:
       display_label: true
     weight: 3
     third_party_settings: {  }
+    region: content
   sticky:
     type: boolean_checkbox
     settings:
       display_label: true
     weight: 4
     third_party_settings: {  }
+    region: content
   path:
     type: path
     weight: 5
     settings: {  }
     third_party_settings: {  }
+    region: content
   body:
     type: text_textarea_with_summary
     weight: 6
@@ -59,11 +65,13 @@ content:
       summary_rows: 3
       placeholder: ''
     third_party_settings: {  }
+    region: content
   field_meta_tags:
     type: metatag_firehose
     weight: 7
     settings: {  }
     third_party_settings: {  }
+    region: content
   scheduled_update:
     type: inline_entity_form_complex
     weight: 8
@@ -75,4 +83,5 @@ content:
       allow_existing: false
       match_operator: CONTAINS
     third_party_settings: {  }
+    region: content
 hidden: {  }

--- a/modules/lightning_features/lightning_core/modules/lightning_page/config/install/core.entity_view_display.node.page.default.yml
+++ b/modules/lightning_features/lightning_core/modules/lightning_page/config/install/core.entity_view_display.node.page.default.yml
@@ -20,14 +20,17 @@ content:
     weight: 0
     settings: {  }
     third_party_settings: {  }
+    region: content
   field_meta_tags:
     type: metatag_empty_formatter
     weight: 2
     label: above
     settings: {  }
     third_party_settings: {  }
+    region: content
   links:
     weight: 1
     settings: {  }
     third_party_settings: {  }
+    region: content
 hidden: {  }

--- a/modules/lightning_features/lightning_core/modules/lightning_page/config/install/core.entity_view_display.node.page.teaser.yml
+++ b/modules/lightning_features/lightning_core/modules/lightning_page/config/install/core.entity_view_display.node.page.teaser.yml
@@ -20,6 +20,8 @@ content:
     settings:
       trim_length: 600
     third_party_settings: {  }
+    region: content
   links:
     weight: 101
+    region: content
 hidden: {  }

--- a/modules/lightning_features/lightning_layout/modules/lightning_landing_page/config/install/core.entity_form_display.node.landing_page.default.yml
+++ b/modules/lightning_features/lightning_layout/modules/lightning_landing_page/config/install/core.entity_form_display.node.landing_page.default.yml
@@ -24,26 +24,31 @@ content:
       placeholder: ''
       summary_rows: 2
     third_party_settings: {  }
+    region: content
   created:
     type: datetime_timestamp
     weight: 3
     settings: {  }
     third_party_settings: {  }
+    region: content
   field_meta_tags:
     weight: 6
     settings: {  }
     third_party_settings: {  }
     type: metatag_firehose
+    region: content
   panelizer:
     type: panelizer
     weight: 5
     settings: {  }
     third_party_settings: {  }
+    region: content
   path:
     type: path
     weight: 4
     settings: {  }
     third_party_settings: {  }
+    region: content
   title:
     type: string_textfield
     weight: 0
@@ -51,6 +56,7 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+    region: content
   uid:
     type: entity_reference_autocomplete
     weight: 2
@@ -59,6 +65,7 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+    region: content
 hidden:
   promote: true
   sticky: true

--- a/modules/lightning_features/lightning_layout/modules/lightning_landing_page/config/install/core.entity_view_display.node.landing_page.default.yml
+++ b/modules/lightning_features/lightning_layout/modules/lightning_landing_page/config/install/core.entity_view_display.node.landing_page.default.yml
@@ -24,19 +24,23 @@ content:
       trim_length: 600
     third_party_settings: {  }
     type: text_summary_or_trimmed
+    region: content
   field_meta_tags:
     weight: 101
     label: above
     settings: {  }
     third_party_settings: {  }
     type: metatag_empty_formatter
+    region: content
   links:
     weight: 100
     settings: {  }
     third_party_settings: {  }
+    region: content
   workbench_moderation_control:
     weight: -20
     settings: {  }
     third_party_settings: {  }
+    region: content
 hidden:
   panelizer: true

--- a/modules/lightning_features/lightning_layout/modules/lightning_landing_page/config/install/core.entity_view_display.node.landing_page.full.yml
+++ b/modules/lightning_features/lightning_layout/modules/lightning_landing_page/config/install/core.entity_view_display.node.landing_page.full.yml
@@ -70,13 +70,16 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: metatag_empty_formatter
+    region: content
   links:
     weight: 100
     settings: {  }
     third_party_settings: {  }
+    region: content
   workbench_moderation_control:
     weight: -20
     settings: {  }
     third_party_settings: {  }
+    region: content
 hidden:
   panelizer: true

--- a/modules/lightning_features/lightning_layout/modules/lightning_landing_page/config/install/core.entity_view_display.node.landing_page.teaser.yml
+++ b/modules/lightning_features/lightning_layout/modules/lightning_landing_page/config/install/core.entity_view_display.node.landing_page.teaser.yml
@@ -24,19 +24,23 @@ content:
       trim_length: 600
     third_party_settings: {  }
     type: text_summary_or_trimmed
+    region: content
   field_meta_tags:
     weight: 101
     label: above
     settings: {  }
     third_party_settings: {  }
     type: metatag_empty_formatter
+    region: content
   links:
     weight: 100
     settings: {  }
     third_party_settings: {  }
+    region: content
   workbench_moderation_control:
     weight: -20
     settings: {  }
     third_party_settings: {  }
+    region: content
 hidden:
   panelizer: true

--- a/modules/lightning_features/lightning_media/modules/lightning_media_document/config/install/core.entity_form_display.media.document.default.yml
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_document/config/install/core.entity_form_display.media.document.default.yml
@@ -18,12 +18,14 @@ content:
       progress_indicator: throbber
     third_party_settings: {  }
     type: file_generic
+    region: content
   field_media_in_library:
     type: boolean_checkbox
     settings:
       display_label: true
     weight: 3
     third_party_settings: {  }
+    region: content
   name:
     type: string_textfield
     weight: 2
@@ -31,6 +33,7 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+    region: content
 hidden:
   created: true
   uid: true

--- a/modules/lightning_features/lightning_media/modules/lightning_media_document/config/install/core.entity_form_display.media.document.media_browser.yml
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_document/config/install/core.entity_form_display.media.document.media_browser.yml
@@ -17,6 +17,7 @@ content:
       display_label: true
     weight: 1
     third_party_settings: {  }
+    region: content
   name:
     type: string_textfield
     weight: 0
@@ -24,6 +25,7 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+    region: content
 hidden:
   created: true
   field_document: true

--- a/modules/lightning_features/lightning_media/modules/lightning_media_document/config/install/core.entity_view_display.media.document.default.yml
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_document/config/install/core.entity_view_display.media.document.default.yml
@@ -24,12 +24,14 @@ content:
       custom_date_format: ''
       timezone: ''
     third_party_settings: {  }
+    region: content
   field_document:
     weight: 2
     label: above
     settings: {  }
     third_party_settings: {  }
     type: file_default
+    region: content
   name:
     label: hidden
     type: string
@@ -37,6 +39,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
+    region: content
   thumbnail:
     type: image
     weight: 1
@@ -45,11 +48,13 @@ content:
       image_style: thumbnail
       image_link: ''
     third_party_settings: {  }
+    region: content
   uid:
     label: hidden
     type: author
     weight: 0
     settings: {  }
     third_party_settings: {  }
+    region: content
 hidden:
   field_media_in_library: true

--- a/modules/lightning_features/lightning_media/modules/lightning_media_document/config/install/core.entity_view_display.media.document.embedded.yml
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_document/config/install/core.entity_view_display.media.document.embedded.yml
@@ -19,6 +19,7 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: file_default
+    region: content
 hidden:
   created: true
   field_media_in_library: true

--- a/modules/lightning_features/lightning_media/modules/lightning_media_document/config/install/core.entity_view_display.media.document.thumbnail.yml
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_document/config/install/core.entity_view_display.media.document.thumbnail.yml
@@ -20,6 +20,7 @@ content:
       image_style: medium
       image_link: ''
     third_party_settings: {  }
+    region: content
 hidden:
   created: true
   field_document: true

--- a/modules/lightning_features/lightning_media/modules/lightning_media_image/config/install/core.entity_form_display.media.image.default.yml
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_image/config/install/core.entity_form_display.media.image.default.yml
@@ -8,7 +8,7 @@ dependencies:
     - media_entity.bundle.image
   module:
     - image
-third_party_settings: { }
+third_party_settings: {  }
 id: media.image.default
 targetEntityType: media
 bundle: image
@@ -20,6 +20,7 @@ content:
     settings:
       display_label: true
     third_party_settings: {  }
+    region: content
   image:
     type: image_image
     weight: 0
@@ -27,6 +28,7 @@ content:
       progress_indicator: throbber
       preview_image_style: thumbnail
     third_party_settings: {  }
+    region: content
   name:
     type: string_textfield
     weight: 3
@@ -34,6 +36,7 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+    region: content
 hidden:
   created: true
   uid: true

--- a/modules/lightning_features/lightning_media/modules/lightning_media_image/config/install/core.entity_form_display.media.image.media_browser.yml
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_image/config/install/core.entity_form_display.media.image.media_browser.yml
@@ -20,6 +20,7 @@ content:
     settings:
       display_label: true
     third_party_settings: {  }
+    region: content
   image:
     type: image_immutable
     weight: 0
@@ -27,6 +28,7 @@ content:
       preview_image_style: medium
       progress_indicator: throbber
     third_party_settings: {  }
+    region: content
   name:
     type: string_textfield
     weight: 3
@@ -34,6 +36,7 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+    region: content
 hidden:
   created: true
   uid: true

--- a/modules/lightning_features/lightning_media/modules/lightning_media_image/config/install/core.entity_view_display.media.image.default.yml
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_image/config/install/core.entity_view_display.media.image.default.yml
@@ -22,6 +22,7 @@ content:
       image_style: ''
       image_link: ''
     third_party_settings: {  }
+    region: content
 hidden:
   created: true
   field_media_in_library: true

--- a/modules/lightning_features/lightning_media/modules/lightning_media_image/config/install/core.entity_view_display.media.image.embedded.yml
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_image/config/install/core.entity_view_display.media.image.embedded.yml
@@ -23,6 +23,7 @@ content:
       image_style: ''
       image_link: ''
     third_party_settings: {  }
+    region: content
 hidden:
   created: true
   field_media_in_library: true

--- a/modules/lightning_features/lightning_media/modules/lightning_media_image/config/install/core.entity_view_display.media.image.thumbnail.yml
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_image/config/install/core.entity_view_display.media.image.thumbnail.yml
@@ -20,6 +20,7 @@ content:
       image_style: medium
       image_link: ''
     third_party_settings: {  }
+    region: content
 hidden:
   created: true
   field_media_in_library: true

--- a/modules/lightning_features/lightning_media/modules/lightning_media_instagram/config/install/core.entity_form_display.media.instagram.default.yml
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_instagram/config/install/core.entity_form_display.media.instagram.default.yml
@@ -5,7 +5,7 @@ dependencies:
     - field.field.media.instagram.embed_code
     - field.field.media.instagram.field_media_in_library
     - media_entity.bundle.instagram
-third_party_settings: { }
+third_party_settings: {  }
 id: media.instagram.default
 targetEntityType: media
 bundle: instagram
@@ -18,12 +18,14 @@ content:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
+    region: content
   field_media_in_library:
     type: boolean_checkbox
     weight: 1
     settings:
       display_label: true
     third_party_settings: {  }
+    region: content
   name:
     type: string_textfield
     weight: 0
@@ -31,7 +33,7 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+    region: content
 hidden:
   created: true
   uid: true
-

--- a/modules/lightning_features/lightning_media/modules/lightning_media_instagram/config/install/core.entity_form_display.media.instagram.media_browser.yml
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_instagram/config/install/core.entity_form_display.media.instagram.media_browser.yml
@@ -17,6 +17,7 @@ content:
     settings:
       display_label: true
     third_party_settings: {  }
+    region: content
   name:
     type: string_textfield
     weight: 0
@@ -24,10 +25,12 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+    region: content
   preview:
     weight: null
     settings: {  }
     third_party_settings: {  }
+    region: content
 hidden:
   created: true
   embed_code: true

--- a/modules/lightning_features/lightning_media/modules/lightning_media_instagram/config/install/core.entity_view_display.media.instagram.default.yml
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_instagram/config/install/core.entity_view_display.media.instagram.default.yml
@@ -22,6 +22,7 @@ content:
       width: '480'
       height: '640'
     third_party_settings: {  }
+    region: content
 hidden:
   created: true
   field_media_in_library: true

--- a/modules/lightning_features/lightning_media/modules/lightning_media_instagram/config/install/core.entity_view_display.media.instagram.embedded.yml
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_instagram/config/install/core.entity_view_display.media.instagram.embedded.yml
@@ -23,6 +23,7 @@ content:
       width: '480'
       height: '640'
     third_party_settings: {  }
+    region: content
 hidden:
   created: true
   field_media_in_library: true

--- a/modules/lightning_features/lightning_media/modules/lightning_media_instagram/config/install/core.entity_view_display.media.instagram.thumbnail.yml
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_instagram/config/install/core.entity_view_display.media.instagram.thumbnail.yml
@@ -20,6 +20,7 @@ content:
       image_style: medium
       image_link: ''
     third_party_settings: {  }
+    region: content
 hidden:
   created: true
   embed_code: true

--- a/modules/lightning_features/lightning_media/modules/lightning_media_twitter/config/install/core.entity_form_display.media.tweet.default.yml
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_twitter/config/install/core.entity_form_display.media.tweet.default.yml
@@ -5,7 +5,7 @@ dependencies:
     - field.field.media.tweet.embed_code
     - field.field.media.tweet.field_media_in_library
     - media_entity.bundle.tweet
-third_party_settings: { }
+third_party_settings: {  }
 id: media.tweet.default
 targetEntityType: media
 bundle: tweet
@@ -18,12 +18,14 @@ content:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
+    region: content
   field_media_in_library:
     type: boolean_checkbox
     weight: 1
     settings:
       display_label: true
     third_party_settings: {  }
+    region: content
   name:
     type: string_textfield
     weight: 0
@@ -31,7 +33,7 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+    region: content
 hidden:
   created: true
   uid: true
-

--- a/modules/lightning_features/lightning_media/modules/lightning_media_twitter/config/install/core.entity_form_display.media.tweet.media_browser.yml
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_twitter/config/install/core.entity_form_display.media.tweet.media_browser.yml
@@ -17,6 +17,7 @@ content:
     settings:
       display_label: true
     third_party_settings: {  }
+    region: content
   name:
     type: string_textfield
     weight: 0
@@ -24,10 +25,12 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+    region: content
   preview:
     weight: null
     settings: {  }
     third_party_settings: {  }
+    region: content
 hidden:
   created: true
   embed_code: true

--- a/modules/lightning_features/lightning_media/modules/lightning_media_twitter/config/install/core.entity_view_display.media.tweet.default.yml
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_twitter/config/install/core.entity_view_display.media.tweet.default.yml
@@ -20,6 +20,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
+    region: content
 hidden:
   created: true
   field_media_in_library: true

--- a/modules/lightning_features/lightning_media/modules/lightning_media_twitter/config/install/core.entity_view_display.media.tweet.embedded.yml
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_twitter/config/install/core.entity_view_display.media.tweet.embedded.yml
@@ -21,6 +21,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
+    region: content
 hidden:
   created: true
   field_media_in_library: true

--- a/modules/lightning_features/lightning_media/modules/lightning_media_twitter/config/install/core.entity_view_display.media.tweet.thumbnail.yml
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_twitter/config/install/core.entity_view_display.media.tweet.thumbnail.yml
@@ -20,6 +20,7 @@ content:
       image_style: medium
       image_link: ''
     third_party_settings: {  }
+    region: content
 hidden:
   created: true
   embed_code: true

--- a/modules/lightning_features/lightning_media/modules/lightning_media_video/config/install/core.entity_form_display.media.video.default.yml
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_video/config/install/core.entity_form_display.media.video.default.yml
@@ -7,7 +7,7 @@ dependencies:
     - media_entity.bundle.video
   module:
     - video_embed_field
-third_party_settings: { }
+third_party_settings: {  }
 id: media.video.default
 targetEntityType: media
 bundle: video
@@ -19,11 +19,13 @@ content:
     settings:
       display_label: true
     third_party_settings: {  }
+    region: content
   field_media_video_embed_field:
     type: video_embed_field_textfield
     weight: 1
     settings: {  }
     third_party_settings: {  }
+    region: content
   name:
     type: string_textfield
     weight: 0
@@ -31,7 +33,7 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+    region: content
 hidden:
   created: true
   uid: true
-

--- a/modules/lightning_features/lightning_media/modules/lightning_media_video/config/install/core.entity_form_display.media.video.media_browser.yml
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_video/config/install/core.entity_form_display.media.video.media_browser.yml
@@ -17,6 +17,7 @@ content:
     settings:
       display_label: true
     third_party_settings: {  }
+    region: content
   name:
     type: string_textfield
     weight: 0
@@ -24,10 +25,12 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+    region: content
   preview:
     weight: null
     settings: {  }
     third_party_settings: {  }
+    region: content
 hidden:
   created: true
   field_media_video_embed_field: true

--- a/modules/lightning_features/lightning_media/modules/lightning_media_video/config/install/core.entity_view_display.media.video.default.yml
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_video/config/install/core.entity_view_display.media.video.default.yml
@@ -22,6 +22,7 @@ content:
       custom_date_format: ''
       timezone: ''
     third_party_settings: {  }
+    region: content
   field_media_video_embed_field:
     type: video_embed_field_video
     weight: 3
@@ -32,6 +33,7 @@ content:
       height: '480'
       autoplay: true
     third_party_settings: {  }
+    region: content
   name:
     label: hidden
     type: string
@@ -39,12 +41,14 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
+    region: content
   uid:
     label: hidden
     type: author
     weight: 2
     settings: {  }
     third_party_settings: {  }
+    region: content
 hidden:
   field_media_in_library: true
   thumbnail: true

--- a/modules/lightning_features/lightning_media/modules/lightning_media_video/config/install/core.entity_view_display.media.video.embedded.yml
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_video/config/install/core.entity_view_display.media.video.embedded.yml
@@ -23,6 +23,7 @@ content:
       height: '480'
       autoplay: true
     third_party_settings: {  }
+    region: content
 hidden:
   created: true
   field_media_in_library: true

--- a/modules/lightning_features/lightning_media/modules/lightning_media_video/config/install/core.entity_view_display.media.video.thumbnail.yml
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_video/config/install/core.entity_view_display.media.video.thumbnail.yml
@@ -20,6 +20,7 @@ content:
       image_style: medium
       image_link: ''
     third_party_settings: {  }
+    region: content
 hidden:
   created: true
   field_media_in_library: true

--- a/modules/lightning_features/lightning_workflow/config/install/core.entity_form_display.scheduled_update.multiple_node_embargo.default.yml
+++ b/modules/lightning_features/lightning_workflow/config/install/core.entity_form_display.scheduled_update.multiple_node_embargo.default.yml
@@ -14,9 +14,11 @@ content:
     weight: 0
     settings: {  }
     third_party_settings: {  }
+    region: content
   update_timestamp:
     type: datetime_timestamp
     weight: -9
     settings: {  }
     third_party_settings: {  }
+    region: content
 hidden: {  }

--- a/modules/lightning_features/lightning_workflow/config/install/core.entity_form_display.scheduled_update.node_embargo.default.yml
+++ b/modules/lightning_features/lightning_workflow/config/install/core.entity_form_display.scheduled_update.node_embargo.default.yml
@@ -14,9 +14,11 @@ content:
     weight: 0
     settings: {  }
     third_party_settings: {  }
+    region: content
   update_timestamp:
     type: datetime_timestamp
     weight: -9
     settings: {  }
     third_party_settings: {  }
+    region: content
 hidden: {  }


### PR DESCRIPTION
See issue: https://www.drupal.org/node/2868087

Used this script by @mortenson to automatically add `region: content` to all entity form and entity view config. Script: https://gist.github.com/mortenson/04bc8e84f3fefbd7ac9404d047d50526