### PR TITLE
Bugfix: Resolves issue in which specified target bundle's source field file extensions are not restricting.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,10 +75,7 @@ install:
   # Build the Lightning code base.
   - composer install
   # Install Lightning cleanly so that settings.php will be created properly.
-  - phing install -Ddb.database=drupal -Ddb.user=lightning -Ddb.password=lightning -Ddb.host=127.0.0.1
-  # Generate Behat configuration.
-  - drupal behat:init http://127.0.0.1:8080 --merge=../tests/behat.yml
-  - drupal behat:include ../tests/features --with-subcontexts=../tests/features/bootstrap --with-subcontexts=../src/LightningExtension/Context
+  - phing install -Ddb.database=drupal -Ddb.user=lightning -Ddb.password=lightning -Ddb.host=127.0.0.1 -Durl=http://127.0.0.1:8080
   # Import the fixture, if it exists.
   - phing recall -Dversion=$VERSION -Ddb.database=drupal -Ddb.user=lightning -Ddb.password=lightning -Ddb.host=127.0.0.1
   - cd docroot

--- a/acquia-pipelines.yml
+++ b/acquia-pipelines.yml
@@ -20,13 +20,10 @@ events:
           script:
             - set -x
             - mysql -u root -proot -e 'CREATE DATABASE drupal;'
-            - ./bin/phing install -Ddb.password=root -Ddb.database=drupal
+            - ./bin/phing install -Ddb.password=root -Ddb.database=drupal -Durl=http://127.0.0.1:8080
             # Add the Acquia cloud database snippet to the settings file.
             - ./bin/phing cloud-db-snippet
             - mkdir -p ./config/default
-            # Generate Behat configuration.
-            - ./bin/drupal behat:init http://127.0.0.1:8080 --merge=../tests/behat.yml
-            - ./bin/drupal behat:include ../tests/features --with-subcontexts=../tests/features/bootstrap --with-subcontexts=../src/LightningExtension/Context
       - test:
           type: script
           script:

--- a/build.xml
+++ b/build.xml
@@ -114,6 +114,10 @@
       </then>
     </if>
 
+    <!-- Generate Behat configuration. -->
+    <exec command="${project.basedir}/bin/drupal behat:init ${url} --merge=${project.basedir}/tests/behat.yml" dir="${docroot}" />
+    <exec command="${project.basedir}/bin/drupal behat:include ${project.basedir}/tests/features --with-subcontexts=${project.basedir}/tests/features/bootstrap --with-subcontexts=${project.basedir}/src/LightningExtension/Context" dir="${docroot}" />
+
     <!-- Export configuration for archaeological purposes. -->
     <property name="config_fixture" value="${project.basedir}/tests/config" />
     <exec command="${drush} config-export --destination=${config_fixture} --yes" dir="${docroot}" />

--- a/modules/lightning_features/lightning_core/modules/lightning_test/config/install/field.field.media.z_image.image.yml
+++ b/modules/lightning_features/lightning_core/modules/lightning_test/config/install/field.field.media.z_image.image.yml
@@ -1,0 +1,37 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.media.image
+    - media_entity.bundle.z_image
+  module:
+    - image
+id: media.z_image.image
+field_name: image
+entity_type: media
+bundle: z_image
+label: Image
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: false
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/modules/lightning_features/lightning_core/modules/lightning_test/config/install/field.field.node.page.field_z_image.yml
+++ b/modules/lightning_features/lightning_core/modules/lightning_test/config/install/field.field.node.page.field_z_image.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_z_image
+    - media_entity.bundle.z_image
+    - node.type.page
+id: node.page.field_z_image
+field_name: field_z_image
+entity_type: node
+bundle: page
+label: 'Z Image'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      z_image: z_image
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/modules/lightning_features/lightning_core/modules/lightning_test/config/install/field.storage.node.field_z_image.yml
+++ b/modules/lightning_features/lightning_core/modules/lightning_test/config/install/field.storage.node.field_z_image.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media_entity
+    - node
+id: node.field_z_image
+field_name: field_z_image
+entity_type: node
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/lightning_features/lightning_core/modules/lightning_test/config/install/media_entity.bundle.z_image.yml
+++ b/modules/lightning_features/lightning_core/modules/lightning_test/config/install/media_entity.bundle.z_image.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media_entity_image
+id: z_image
+label: 'Z Image'
+description: ''
+type: image
+queue_thumbnail_downloads: false
+new_revision: false
+type_configuration:
+  source_field: image
+  gather_exif: false
+field_map: {  }

--- a/modules/lightning_features/lightning_core/modules/lightning_test/lightning_test.install
+++ b/modules/lightning_features/lightning_core/modules/lightning_test/lightning_test.install
@@ -8,7 +8,6 @@
 use Drupal\Core\Form\FormState;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\entity_browser\Element\EntityBrowserElement;
-use Drupal\multiversion\Entity\Storage\ContentEntityStorageInterface;
 
 /**
  * Implements hook_install().
@@ -26,6 +25,7 @@ function lightning_test_install() {
         'open' => TRUE,
         'selection_mode' => EntityBrowserElement::SELECTION_MODE_APPEND,
       ],
+      'region' => 'content',
     ])
     ->setComponent('field_hero_image', [
       'type' => 'entity_browser_file',
@@ -38,6 +38,7 @@ function lightning_test_install() {
         'open' => TRUE,
         'selection_mode' => EntityBrowserElement::SELECTION_MODE_APPEND,
       ],
+      'region' => 'content',
     ])
     ->setComponent('field_lightweight_image', [
       'type' => 'entity_browser_file',
@@ -50,6 +51,7 @@ function lightning_test_install() {
         'open' => TRUE,
         'selection_mode' => EntityBrowserElement::SELECTION_MODE_APPEND,
       ],
+      'region' => 'content',
     ])
     ->setComponent('field_unlimited_images', [
       'type' => 'entity_browser_file',
@@ -62,6 +64,7 @@ function lightning_test_install() {
         'open' => TRUE,
         'selection_mode' => EntityBrowserElement::SELECTION_MODE_APPEND,
       ],
+      'region' => 'content',
     ])
     ->setComponent('field_media_reference', [
       'type' => 'entity_browser_entity_reference',
@@ -76,6 +79,22 @@ function lightning_test_install() {
         ],
         'open' => TRUE,
       ],
+      'region' => 'content',
+    ])
+    ->setComponent('field_z_image', [
+      'type' => 'entity_browser_entity_reference',
+      'settings' => [
+        'entity_browser' => 'media_browser',
+        'field_widget_display' => 'rendered_entity',
+        'field_widget_edit' => TRUE,
+        'field_widget_remove' => TRUE,
+        'selection_mode' => EntityBrowserElement::SELECTION_MODE_APPEND,
+        'field_widget_display_settings' => [
+          'view_mode' => 'embedded',
+        ],
+        'open' => TRUE,
+      ],
+      'region' => 'content',
     ])
     ->save();
 
@@ -109,12 +128,6 @@ function lightning_test_uninstall() {
     $storage = \Drupal::entityTypeManager()->getStorage($entity_type);
     $entities = $storage->loadMultiple($entities);
     $storage->delete($entities);
-
-    // If this is a Multiversion-aware entity type, we need to explicitly purge
-    // the entities from the database.
-    if ($storage instanceof ContentEntityStorageInterface) {
-      $storage->purge($entities);
-    }
   }
   $state->delete('_delete');
 
@@ -131,4 +144,9 @@ function lightning_test_uninstall() {
     }
   }
   $state->delete('_fields');
+
+  \Drupal::entityTypeManager()
+    ->getStorage('media_bundle')
+    ->load('z_image')
+    ->delete();
 }

--- a/modules/lightning_features/lightning_core/src/BundleEntityStorage.php
+++ b/modules/lightning_features/lightning_core/src/BundleEntityStorage.php
@@ -64,4 +64,23 @@ class BundleEntityStorage extends ConfigEntityStorage {
     return parent::loadMultiple($ids);
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function loadByProperties(array $values = [], $check_access = FALSE) {
+    // Build a query to fetch the entity IDs.
+    $entity_query = $this->getQuery();
+    $this->buildPropertyQuery($entity_query, $values);
+    if ($check_access) {
+      $result = array_filter($entity_query->execute(), [
+        $this->accessHandler,
+        'createAccess'
+      ]);
+    }
+    else {
+      $result = $entity_query->execute();
+    }
+    return $result ? parent::loadMultiple($result) : [];
+  }
+
 }

--- a/modules/lightning_features/lightning_core/src/BundleEntityStorage.php
+++ b/modules/lightning_features/lightning_core/src/BundleEntityStorage.php
@@ -71,15 +71,12 @@ class BundleEntityStorage extends ConfigEntityStorage {
     // Build a query to fetch the entity IDs.
     $entity_query = $this->getQuery();
     $this->buildPropertyQuery($entity_query, $values);
+    $result = $entity_query->execute();
+
     if ($check_access) {
-      $result = array_filter($entity_query->execute(), [
-        $this->accessHandler,
-        'createAccess'
-      ]);
+      $result = array_filter($result, [$this->accessHandler, 'createAccess']);
     }
-    else {
-      $result = $entity_query->execute();
-    }
+
     return $result ? parent::loadMultiple($result) : [];
   }
 

--- a/modules/lightning_features/lightning_core/src/BundleEntityStorage.php
+++ b/modules/lightning_features/lightning_core/src/BundleEntityStorage.php
@@ -57,7 +57,7 @@ class BundleEntityStorage extends ConfigEntityStorage {
   public function loadMultiple(array $ids = NULL, $check_access = FALSE) {
     if ($check_access) {
       $ids = array_filter(
-        $this->getQuery()->execute(),
+        $ids ?: $this->getQuery()->execute(),
         [$this->accessHandler, 'createAccess']
       );
     }

--- a/modules/lightning_features/lightning_core/src/BundleEntityStorage.php
+++ b/modules/lightning_features/lightning_core/src/BundleEntityStorage.php
@@ -64,20 +64,4 @@ class BundleEntityStorage extends ConfigEntityStorage {
     return parent::loadMultiple($ids);
   }
 
-  /**
-   * {@inheritdoc}
-   */
-  public function loadByProperties(array $values = [], $check_access = FALSE) {
-    // Build a query to fetch the entity IDs.
-    $entity_query = $this->getQuery();
-    $this->buildPropertyQuery($entity_query, $values);
-    $result = $entity_query->execute();
-
-    if ($check_access) {
-      $result = array_filter($result, [$this->accessHandler, 'createAccess']);
-    }
-
-    return $result ? parent::loadMultiple($result) : [];
-  }
-
 }

--- a/modules/lightning_features/lightning_media/lightning_media.module
+++ b/modules/lightning_features/lightning_media/lightning_media.module
@@ -96,13 +96,16 @@ function lightning_media_inline_entity_form_entity_form_alter(array &$entity_for
  *
  * @param \Drupal\file\FileInterface $file
  *   The file to validate.
+ * @param string[] $bundles
+ *   (optional) A set of media bundle IDs which might match the input. If
+ *   omitted, all bundles to which the user has create access will be checked.
  *
  * @return string[]
  *   An array of errors. If empty, the file passed validation.
  */
-function lightning_media_validate_upload(FileInterface $file) {
+function lightning_media_validate_upload(FileInterface $file, array $bundles = []) {
   try {
-    $entity = \Drupal::service('lightning.media_helper')->createFromInput($file);
+    $entity = \Drupal::service('lightning.media_helper')->createFromInput($file, $bundles);
   }
   catch (IndeterminateBundleException $e) {
     return [];

--- a/modules/lightning_features/lightning_media/lightning_media.module
+++ b/modules/lightning_features/lightning_media/lightning_media.module
@@ -398,6 +398,7 @@ function lightning_media_entity_form_display_presave(EntityFormDisplayInterface 
         ],
         'open' => TRUE,
       ],
+      'region' => 'content',
     ]);
   }
 }

--- a/modules/lightning_features/lightning_media/modules/lightning_media_image/lightning_media_image.module
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_image/lightning_media_image.module
@@ -81,6 +81,7 @@ function lightning_media_image_entity_form_display_presave(EntityFormDisplayInte
         'preview_image_style' => 'thumbnail',
         'open' => TRUE,
       ],
+      'region' => 'content',
     ]);
   }
 }

--- a/modules/lightning_features/lightning_media/src/MediaHelper.php
+++ b/modules/lightning_features/lightning_media/src/MediaHelper.php
@@ -62,7 +62,7 @@ class MediaHelper {
         // If the field is a FileItem or any of its descendants, we can consider
         // it a file field. This will automatically include things like image
         // fields, which extend file fields.
-        if (!empty($field) && is_a($field->getItemDefinition()->getClass(), FileItem::class, TRUE)) {
+        if (is_a($field->getItemDefinition()->getClass(), FileItem::class, TRUE)) {
           $extensions .= $field->getSetting('file_extensions') . ' ';
         }
       }

--- a/modules/lightning_features/lightning_media/src/MediaHelper.php
+++ b/modules/lightning_features/lightning_media/src/MediaHelper.php
@@ -37,17 +37,26 @@ class MediaHelper {
    *   (optional) Whether to filter the bundles by create access for the current
    *   user. Defaults to FALSE.
    *
+   * @param array $target_bundles
+   *   (optional) An array of target bundles to retrieve source field extensions
+   *   for. Defaults to empty array.
+   *
    * @return string[]
    *   The file extensions accepted by all available bundles.
    */
-  public function getFileExtensions($check_access = FALSE) {
+  public function getFileExtensions($check_access = FALSE, array $target_bundles = []) {
     $extensions = '';
 
     // Lightning Media overrides the media_bundle storage handler with a special
     // one that adds an optional second parameter to loadMultiple().
-    $bundles = $this->entityTypeManager
-      ->getStorage('media_bundle')
-      ->loadMultiple(NULL, $check_access);
+    $storage = $this->entityTypeManager
+      ->getStorage('media_bundle');
+    if (!empty($target_bundles)) {
+      $bundles = $storage->loadByProperties(['id' => $target_bundles], $check_access);
+    }
+    else {
+      $bundles = $storage->loadMultiple(NULL, $check_access);
+    }
 
     /** @var \Drupal\media_entity\MediaBundleInterface $bundle */
     foreach ($bundles as $bundle) {

--- a/modules/lightning_features/lightning_media/src/MediaHelper.php
+++ b/modules/lightning_features/lightning_media/src/MediaHelper.php
@@ -36,10 +36,9 @@ class MediaHelper {
    * @param bool $check_access
    *   (optional) Whether to filter the bundles by create access for the current
    *   user. Defaults to FALSE.
-   *
-   * @param array $target_bundles
+   * @param string[] $target_bundles
    *   (optional) An array of target bundles to retrieve source field extensions
-   *   for. Defaults to empty array.
+   *   for. If omitted, all bundles are allowed.
    *
    * @return string[]
    *   The file extensions accepted by all available bundles.

--- a/modules/lightning_features/lightning_media/src/MediaHelper.php
+++ b/modules/lightning_features/lightning_media/src/MediaHelper.php
@@ -50,12 +50,7 @@ class MediaHelper {
     // one that adds an optional second parameter to loadMultiple().
     $storage = $this->entityTypeManager
       ->getStorage('media_bundle');
-    if (!empty($target_bundles)) {
-      $bundles = $storage->loadByProperties(['id' => $target_bundles], $check_access);
-    }
-    else {
-      $bundles = $storage->loadMultiple(NULL, $check_access);
-    }
+    $bundles = $storage->loadMultiple($target_bundles ?: NULL, $check_access);
 
     /** @var \Drupal\media_entity\MediaBundleInterface $bundle */
     foreach ($bundles as $bundle) {

--- a/modules/lightning_features/lightning_media/src/MediaHelper.php
+++ b/modules/lightning_features/lightning_media/src/MediaHelper.php
@@ -62,7 +62,7 @@ class MediaHelper {
         // If the field is a FileItem or any of its descendants, we can consider
         // it a file field. This will automatically include things like image
         // fields, which extend file fields.
-        if (is_a($field->getItemDefinition()->getClass(), FileItem::class, TRUE)) {
+        if (!empty($field) && is_a($field->getItemDefinition()->getClass(), FileItem::class, TRUE)) {
           $extensions .= $field->getSetting('file_extensions') . ' ';
         }
       }

--- a/modules/lightning_features/lightning_media/src/Plugin/EntityBrowser/Widget/FileUpload.php
+++ b/modules/lightning_features/lightning_media/src/Plugin/EntityBrowser/Widget/FileUpload.php
@@ -65,8 +65,13 @@ class FileUpload extends EntityFormProxy {
     // it as the first validator, allowing it to accept only file extensions
     // associated with existing media bundles.
     if (empty($validators['file_validate_extensions'])) {
+      $target_bundles = [];
       $entity_browser_info = $form_state->get('entity_browser');
-      $target_bundles = !empty($entity_browser_info['widget_context']['target_bundles']) ? $entity_browser_info['widget_context']['target_bundles'] : [];
+      if (!empty($entity_browser_info['widget_context']['target_bundles'])) {
+        if (is_array($entity_browser_info['widget_context']['target_bundles'])) {
+          $target_bundles = $entity_browser_info['widget_context']['target_bundles'];
+        }
+      }
 
       $validators = array_merge([
         'file_validate_extensions' => [

--- a/modules/lightning_features/lightning_media/src/Plugin/EntityBrowser/Widget/FileUpload.php
+++ b/modules/lightning_features/lightning_media/src/Plugin/EntityBrowser/Widget/FileUpload.php
@@ -68,9 +68,7 @@ class FileUpload extends EntityFormProxy {
       $target_bundles = [];
       $entity_browser_info = $form_state->get('entity_browser');
       if (!empty($entity_browser_info['widget_context']['target_bundles'])) {
-        if (is_array($entity_browser_info['widget_context']['target_bundles'])) {
-          $target_bundles = $entity_browser_info['widget_context']['target_bundles'];
-        }
+        $target_bundles = $entity_browser_info['widget_context']['target_bundles'];
       }
 
       $validators = array_merge([

--- a/modules/lightning_features/lightning_media/src/Plugin/EntityBrowser/Widget/FileUpload.php
+++ b/modules/lightning_features/lightning_media/src/Plugin/EntityBrowser/Widget/FileUpload.php
@@ -65,9 +65,12 @@ class FileUpload extends EntityFormProxy {
     // it as the first validator, allowing it to accept only file extensions
     // associated with existing media bundles.
     if (empty($validators['file_validate_extensions'])) {
+      $entity_browser_info = $form_state->get('entity_browser');
+      $target_bundles = !empty($entity_browser_info['widget_context']['target_bundles']) ? $entity_browser_info['widget_context']['target_bundles'] : [];
+
       $validators = array_merge([
         'file_validate_extensions' => [
-          implode(' ', $this->helper->getFileExtensions(TRUE)),
+          implode(' ', $this->helper->getFileExtensions(TRUE, $target_bundles)),
         ],
         // This must be a function because file_validate() still thinks that
         // function_exists() is a good way to ensure callability.

--- a/modules/lightning_features/lightning_media/src/Plugin/EntityBrowser/Widget/FileUpload.php
+++ b/modules/lightning_features/lightning_media/src/Plugin/EntityBrowser/Widget/FileUpload.php
@@ -65,19 +65,21 @@ class FileUpload extends EntityFormProxy {
     // it as the first validator, allowing it to accept only file extensions
     // associated with existing media bundles.
     if (empty($validators['file_validate_extensions'])) {
-      $target_bundles = [];
+      $bundles = [];
       $entity_browser_info = $form_state->get('entity_browser');
       if (!empty($entity_browser_info['widget_context']['target_bundles'])) {
-        $target_bundles = $entity_browser_info['widget_context']['target_bundles'];
+        $bundles = $entity_browser_info['widget_context']['target_bundles'];
       }
 
       $validators = array_merge([
         'file_validate_extensions' => [
-          implode(' ', $this->helper->getFileExtensions(TRUE, $target_bundles)),
+          implode(' ', $this->helper->getFileExtensions(TRUE, $bundles)),
         ],
         // This must be a function because file_validate() still thinks that
         // function_exists() is a good way to ensure callability.
-        'lightning_media_validate_upload' => [],
+        'lightning_media_validate_upload' => [
+          $bundles,
+        ],
       ], $validators);
     }
     $form['input']['#upload_validators'] = $validators;

--- a/src/LightningExtension/Context/UtilityContext.behat.inc
+++ b/src/LightningExtension/Context/UtilityContext.behat.inc
@@ -213,4 +213,69 @@ class UtilityContext extends DrupalSubContextBase {
     }
   }
 
+  /**
+   * Asserts the existence of entities by running a count query.
+   *
+   * @param string $entity_type
+   *   The entity type ID.
+   * @param int $count
+   *   The expected number of entities.
+   * @param string $bundle
+   *   (optional) The bundle to filter by.
+   *
+   * @throws \Behat\Mink\Exception\ExpectationException if there are not exactly
+   * as many entities of the given type and bundle as expected.
+   *
+   * @Then there should be :count :entity_type entities
+   * @Then there should be :count :bundle :entity_type entities
+   */
+  public function assertEntityExistence($entity_type, $count, $bundle = NULL) {
+    $query = \Drupal::entityQuery($entity_type)->count();
+
+    if ($bundle) {
+      $query->condition(
+        \Drupal::entityTypeManager()->getDefinition($entity_type)->getKey('bundle'),
+        $bundle
+      );
+    }
+    $exists = (int) $query->execute();
+
+    if ($exists !== $count) {
+      throw new ExpectationException(
+        "Expected {$count} {$entity_type} entities, but found {$exists}.",
+        $this->getSession()->getDriver()
+      );
+    }
+  }
+
+  /**
+   * Asserts the existence of a single entity by running a count query.
+   *
+   * @param string $entity_type
+   *   The entity type ID.
+   * @param string $bundle
+   *   (optional) The bundle to filter by.
+   *
+   * @Then there should be one :entity_type entity
+   * @Then there should be one :bundle :entity_type entity
+   */
+  public function assertEntityExistenceOne($entity_type, $bundle = NULL) {
+    $this->assertEntityExistence($entity_type, 1, $bundle);
+  }
+
+  /**
+   * Asserts the non-existence of entities by running a count query.
+   *
+   * @param string $entity_type
+   *   The entity type ID.
+   * @param string $bundle
+   *   (optional) The bundle to filter by.
+   *
+   * @Then there should be no :entity_type entities
+   * @Then there should be no :bundle :entity_type entities
+   */
+  public function assertEntityNonExistence($entity_type, $bundle = NULL) {
+    $this->assertEntityExistence($entity_type, 0, $bundle);
+  }
+
 }

--- a/src/LightningExtension/Context/UtilityContext.behat.inc
+++ b/src/LightningExtension/Context/UtilityContext.behat.inc
@@ -228,6 +228,8 @@ class UtilityContext extends DrupalSubContextBase {
    *
    * @Then there should be :count :entity_type entities
    * @Then there should be :count :bundle :entity_type entities
+   * @Then there should be :count :entity_type entity
+   * @Then there should be :count :bundle :entity_type entity
    */
   public function assertEntityExistence($entity_type, $count, $bundle = NULL) {
     $query = \Drupal::entityQuery($entity_type)->count();
@@ -238,44 +240,14 @@ class UtilityContext extends DrupalSubContextBase {
         $bundle
       );
     }
-    $exists = (int) $query->execute();
+    $exists = $query->execute();
 
-    if ($exists !== $count) {
+    if ((int) $exists !== (int) $count) {
       throw new ExpectationException(
         "Expected {$count} {$entity_type} entities, but found {$exists}.",
         $this->getSession()->getDriver()
       );
     }
-  }
-
-  /**
-   * Asserts the existence of a single entity by running a count query.
-   *
-   * @param string $entity_type
-   *   The entity type ID.
-   * @param string $bundle
-   *   (optional) The bundle to filter by.
-   *
-   * @Then there should be one :entity_type entity
-   * @Then there should be one :bundle :entity_type entity
-   */
-  public function assertEntityExistenceOne($entity_type, $bundle = NULL) {
-    $this->assertEntityExistence($entity_type, 1, $bundle);
-  }
-
-  /**
-   * Asserts the non-existence of entities by running a count query.
-   *
-   * @param string $entity_type
-   *   The entity type ID.
-   * @param string $bundle
-   *   (optional) The bundle to filter by.
-   *
-   * @Then there should be no :entity_type entities
-   * @Then there should be no :bundle :entity_type entities
-   */
-  public function assertEntityNonExistence($entity_type, $bundle = NULL) {
-    $this->assertEntityExistence($entity_type, 0, $bundle);
   }
 
 }

--- a/tests/features/media/browser_upload.feature
+++ b/tests/features/media/browser_upload.feature
@@ -54,3 +54,13 @@ Feature: Uploading media assets through the media browser
     And I attach the file "test.php" to "input_file"
     And I wait for AJAX to finish
     Then the "#entity" element should be empty
+
+  @test_module @ced013a5
+  Scenario: The upload widget should respect media bundles allowed by the field
+    Given I am logged in as a user with the "page_creator,media_creator,media_manager" roles
+    When I visit "/node/add/page"
+    And I switch to the "entity_browser_iframe_media_browser" frame
+    And I upload "test.jpg"
+    And I enter "Z Image Test" for "Media name"
+    And I submit the entity browser
+    Then there should be one z_image media entity

--- a/tests/features/media/browser_upload.feature
+++ b/tests/features/media/browser_upload.feature
@@ -63,4 +63,5 @@ Feature: Uploading media assets through the media browser
     And I upload "test.jpg"
     And I enter "Z Image Test" for "Media name"
     And I submit the entity browser
-    Then there should be one z_image media entity
+    Then there should be 1 z_image media entity
+    And there should be 0 image media entities


### PR DESCRIPTION
## Problem

File extensions specified on the media bundle's source field are not adhered too and do not restrict users from uploading files of other media bundle type's file extensions.

For example, an Image field which has a source field specifying an Image with file extensions set as `png, jpeg, jpg, gif` are not restricting users from uploading additional file extensions configured on _other_ media bundle's source fields that may not be of type image - an example would be a Document bundle, allowing for `pdf, txt, doc, docx` file extensions. These file types _could_ be uploaded within the Image media bundle as well. 