### PR TITLE
Move install-state Behat tests to PHPUnit

### DIFF
--- a/tests/features/media/roles.feature
+++ b/tests/features/media/roles.feature
@@ -1,24 +1,6 @@
 @lightning @core @media @api
 Feature: Responsibility-based user roles for creating and managing media assets
 
-  @beta5 @80dd53a1
-  Scenario: Media-related user roles should exist
-    Given I am logged in as a user with the "administer permissions" permission
-    When I visit "/admin/people/roles"
-    Then I should see "Media Creator"
-    And I should see "Media Manager"
-
-  @beta5 @68d467b4
-  Scenario: Content creators have access to the rich_text input format and entity browsers
-    Given I am logged in as a user with the "administer permissions" permission
-    When I visit "/admin/people/permissions"
-    Then the page_creator role should have permission to:
-      """
-      use text format rich_text
-      access media_browser entity browser pages
-      access image_browser entity browser pages
-      """
-
   @video @beta5 @d2a26938
   Scenario: Creating media as a media creator
     Given I am logged in as a user with the media_creator role

--- a/tests/src/Functional/ConfigIntegrityTest.php
+++ b/tests/src/Functional/ConfigIntegrityTest.php
@@ -37,6 +37,16 @@ class ConfigIntegrityTest extends BrowserTestBase {
     // All users should be able to view media items.
     $this->assertContains('view media', Role::load('anonymous')->getPermissions());
     $this->assertContains('view media', Role::load('authenticated')->getPermissions());
+
+    // Assert that media-related roles exist.
+    $this->assertInstanceOf(Role::class, Role::load('media_creator'));
+    $this->assertInstanceOf(Role::class, Role::load('media_manager'));
+
+    // Assert that page creators have expected permissions.
+    $permissions = Role::load('page_creator')->getPermissions();
+    $this->assertContains('use text format rich_text', $permissions);
+    $this->assertContains('access media_browser entity browser pages', $permissions);
+    $this->assertContains('access image_browser entity browser pages', $permissions);
   }
 
 }


### PR DESCRIPTION
A couple of our Behat tests don't actually test functionality, but only verify the state of various permissions and other install-time configuration. Now that we have a functional PHPUnit test that passes, these tests should not be done in Behat. This will shave a little time off our Travis CI runs.