### PR TITLE
Add UUIDs to field storage configs

### DIFF
--- a/modules/lightning_features/lightning_core/config/install/field.storage.node.field_meta_tags.yml
+++ b/modules/lightning_features/lightning_core/config/install/field.storage.node.field_meta_tags.yml
@@ -1,3 +1,4 @@
+uuid: 8fac44a0-73ae-4055-b75c-1181b79f6608
 langcode: en
 status: true
 dependencies:

--- a/modules/lightning_features/lightning_layout/config/install/field.storage.node.panelizer.yml
+++ b/modules/lightning_features/lightning_layout/config/install/field.storage.node.panelizer.yml
@@ -1,3 +1,4 @@
+uuid: 69a4c29f-f3b3-4ebe-ac8f-b8f05651f528
 langcode: en
 status: true
 dependencies:

--- a/modules/lightning_features/lightning_media/config/install/field.storage.media.embed_code.yml
+++ b/modules/lightning_features/lightning_media/config/install/field.storage.media.embed_code.yml
@@ -1,3 +1,4 @@
+uuid: 62bf66dd-0ded-43f1-8a6d-21049dcf611f
 langcode: en
 status: true
 dependencies:

--- a/modules/lightning_features/lightning_media/config/install/field.storage.media.field_media_in_library.yml
+++ b/modules/lightning_features/lightning_media/config/install/field.storage.media.field_media_in_library.yml
@@ -1,3 +1,4 @@
+uuid: ca668034-8b54-4ae6-b336-705f469d1b20
 langcode: en
 status: true
 dependencies:

--- a/modules/lightning_features/lightning_media/config/install/field.storage.media.image.yml
+++ b/modules/lightning_features/lightning_media/config/install/field.storage.media.image.yml
@@ -1,3 +1,4 @@
+uuid: 35196e7b-89b3-40b7-a853-bf41a604c979
 langcode: und
 status: true
 dependencies:

--- a/modules/lightning_features/lightning_media/modules/lightning_media_document/config/install/field.storage.media.field_document.yml
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_document/config/install/field.storage.media.field_document.yml
@@ -1,3 +1,4 @@
+uuid: a763a239-c88a-4078-90f6-4a63af859f94
 langcode: en
 status: true
 dependencies:

--- a/modules/lightning_features/lightning_media/modules/lightning_media_video/config/install/field.storage.media.field_media_video_embed_field.yml
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_video/config/install/field.storage.media.field_media_video_embed_field.yml
@@ -1,3 +1,4 @@
+uuid: fd3e44e6-ecc1-4079-bf98-156f5375cc41
 langcode: en
 status: true
 dependencies:

--- a/modules/lightning_features/lightning_workflow/config/install/field.storage.node.scheduled_update.yml
+++ b/modules/lightning_features/lightning_workflow/config/install/field.storage.node.scheduled_update.yml
@@ -1,3 +1,4 @@
+uuid: 421d7428-30be-4c49-93bd-01a9c4988344
 langcode: en
 status: true
 dependencies:

--- a/modules/lightning_features/lightning_workflow/config/install/field.storage.scheduled_update.field_moderation_state.yml
+++ b/modules/lightning_features/lightning_workflow/config/install/field.storage.scheduled_update.field_moderation_state.yml
@@ -1,3 +1,4 @@
+uuid: 61fab641-d303-4f66-829f-d37398c07b91
 langcode: en
 status: true
 dependencies:


### PR DESCRIPTION
Fixes #387 from Lightning's perspective. Core still provides two field storage config definitions that don't include UUIDs (field.storage.block_content.body.yml and field.storage.node.body.yml). This adds UUIDs to all of Lightning's field storage config.