### PR TITLE
Don't install Page Manager

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -60,6 +60,11 @@ Beta 2, then from Beta 2 to Beta 3, in that order.
   * **Toolbar**: Use the administration toolbar
   * **Quick Edit**: Access in-place editing
   * **Contextual Links**: Use contextual links
+* Page Manager is no longer a dependency of Lightning Layout, and it will no
+  longer ship with Lightning as of the next release. Therefore, if you are
+  actively using Page Manager, you must add it to your project as an explicit
+  dependency in order to continue to using it. Otherwise, you should uninstall
+  it before updating to the next version of Lightning.
 
 ## 2.1.5 to 2.1.6
 This version of Lightning adds the ability to choose an image style, alt text,

--- a/modules/lightning_features/lightning_core/modules/lightning_dev/lightning_dev.install
+++ b/modules/lightning_features/lightning_core/modules/lightning_dev/lightning_dev.install
@@ -222,4 +222,6 @@ function lightning_dev_update_8007() {
       'access contextual links',
       'access toolbar',
     ]);
+
+  \Drupal::service('module_installer')->uninstall(['page_manager']);
 }

--- a/modules/lightning_features/lightning_layout/lightning_layout.info.yml
+++ b/modules/lightning_features/lightning_layout/lightning_layout.info.yml
@@ -6,7 +6,6 @@ version: '8.x-2.17-dev'
 package: Lightning
 dependencies:
   - lightning_core
-  - page_manager
   - panelizer
   - panelizer_quickedit
 components:


### PR DESCRIPTION
Lightning Layout has been installing Page Manager up to this point, but it doesn't actually use it for anything. This PR removes it as a dependency from Lightning Layout.