### PR TITLE
Remove hard dependency on Menu UI

### DIFF
--- a/modules/lightning_features/lightning_core/lightning_core.info.yml
+++ b/modules/lightning_features/lightning_core/lightning_core.info.yml
@@ -5,7 +5,6 @@ package: Lightning
 description: 'Shared functionality for the Lightning distribution.'
 version: '8.x-2.17-dev'
 dependencies:
-  - menu_ui
   - metatag
   - node
   - path


### PR DESCRIPTION
Lightning Core has a hard dependency on Menu UI which appears to serve no real purpose. I'm not sure why it's there, but it doesn't break our tests to remove it. Menu UI is already installed by the Lightning profile anyway.