### PR TITLE
Remove menu_ui dependency from page node type

### DIFF
--- a/modules/lightning_features/lightning_core/modules/lightning_page/config/install/node.type.page.yml
+++ b/modules/lightning_features/lightning_core/modules/lightning_page/config/install/node.type.page.yml
@@ -1,8 +1,5 @@
 langcode: en
 status: true
-dependencies:
-  module:
-    - menu_ui
 third_party_settings:
   menu_ui:
     available_menus:


### PR DESCRIPTION
It turns out that the page node type (bundled with lightning_page) contains a dependency on menu_ui, due to third-party settings provided by that module. As far as I know, third-party settings are preserved even if the provider is not there, so it should be OK to remove the hard dependency. That is what we do here.

This blocks acquia/headless-lightning#18.