### PR TITLE
Provide inline links to API documentation for bundle config entities

### DIFF
--- a/modules/lightning_features/lightning_api/lightning_api.module
+++ b/modules/lightning_features/lightning_api/lightning_api.module
@@ -1,5 +1,7 @@
 <?php
 
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Url;
 use Drupal\lightning_api\OAuthHelper;
 
 /**
@@ -29,4 +31,28 @@ function lightning_api_modules_installed(array $modules) {
       drupal_set_message($error, 'error');
     }
   }
+}
+
+/**
+ * Implements hook_entity_operation().
+ */
+function lightning_api_entity_operation(EntityInterface $entity) {
+  $operations = [];
+
+  $bundle_of = $entity->getEntityType()->getBundleOf();
+  if ($bundle_of) {
+    $fragment = str_replace(' ', '-', sprintf(
+      'tag/%s-%s',
+      \Drupal::entityTypeManager()->getDefinition($bundle_of)->getLabel(),
+      $entity->label()
+    ));
+
+    $operations['api-documentation'] = [
+      'title' => t('View API documentation'),
+      'url' => Url::fromRoute('openapi_redoc.jsonapi', [], ['fragment' => $fragment]),
+      'weight' => 50,
+    ];
+  }
+
+  return $operations;
 }


### PR DESCRIPTION
The OpenAPI ReDoc module generates API documentation for all bundle config entities (such as node types, media types, etc.) A nice little thing that Lightning API could do -- and Headless Lightning could take advantage of -- is to provide an inline "View API documentation" link for all such entities. This PR does exactly that, revealed in the operations drop-button of each bundle config entity listed in a standard table.

I didn't bother with tests because this is very low-risk and doesn't alter user data in any way. But I can add one if needed.