### PR TITLE
Add an operation to view entities as JSON

### DIFF
--- a/modules/lightning_features/lightning_api/config/install/lightning_api.settings.yml
+++ b/modules/lightning_features/lightning_api/config/install/lightning_api.settings.yml
@@ -1,0 +1,1 @@
+entity_json: false

--- a/modules/lightning_features/lightning_api/config/schema/lightning_api.schema.yml
+++ b/modules/lightning_features/lightning_api/config/schema/lightning_api.schema.yml
@@ -1,0 +1,7 @@
+lightning_api.settings:
+  type: config_object
+  label: 'Content API settings'
+  mapping:
+    entity_json:
+      type: boolean
+      label: 'Expose "View JSON" link in entity operations'

--- a/modules/lightning_features/lightning_api/lightning_api.links.task.yml
+++ b/modules/lightning_features/lightning_api/lightning_api.links.task.yml
@@ -1,0 +1,4 @@
+lightning_api.settings:
+  route_name: lightning_api.settings
+  title: 'API'
+  base_route: lightning_core.settings

--- a/modules/lightning_features/lightning_api/lightning_api.module
+++ b/modules/lightning_features/lightning_api/lightning_api.module
@@ -33,11 +33,43 @@ function lightning_api_modules_installed(array $modules) {
   }
 }
 
+function lightning_api_entity_json(EntityInterface $entity) {
+  $allowed = \Drupal::config('lightning_api.settings')
+    ->get('entity_json');
+
+  $uuid = $entity->uuid();
+
+  /** @var \Drupal\jsonapi\ResourceType\ResourceType $resource_type */
+  $resource_type = \Drupal::service('jsonapi.resource_type.repository')
+    ->get(
+      $entity->getEntityTypeId(),
+      $entity->bundle()
+    );
+
+  if ($allowed && $uuid && $resource_type) {
+    return Url::fromRoute(
+      'jsonapi.' . $resource_type->getTypeName() . '.individual',
+      [
+        $resource_type->getEntityTypeId() => $uuid,
+      ]
+    );
+  }
+}
+
 /**
  * Implements hook_entity_operation().
  */
 function lightning_api_entity_operation(EntityInterface $entity) {
   $operations = [];
+
+  $url = lightning_api_entity_json($entity);
+  if ($url) {
+    $operations['view-json'] = [
+      'title' => t('View JSON'),
+      'url' => $url,
+      'weight' => 50,
+    ];
+  }
 
   $bundle_of = $entity->getEntityType()->getBundleOf();
   if ($bundle_of) {
@@ -50,7 +82,7 @@ function lightning_api_entity_operation(EntityInterface $entity) {
     $operations['api-documentation'] = [
       'title' => t('View API documentation'),
       'url' => Url::fromRoute('openapi_redoc.jsonapi', [], ['fragment' => $fragment]),
-      'weight' => 50,
+      'weight' => 51,
     ];
   }
 

--- a/modules/lightning_features/lightning_api/lightning_api.module
+++ b/modules/lightning_features/lightning_api/lightning_api.module
@@ -3,6 +3,7 @@
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Url;
 use Drupal\lightning_api\OAuthHelper;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
 /**
  * Implements hook_modules_installed().
@@ -33,9 +34,19 @@ function lightning_api_modules_installed(array $modules) {
   }
 }
 
+/**
+ * Implements hook_entity_insert().
+ */
+function lightning_api_entity_insert(EntityInterface $entity) {
+  $allowed = \Drupal::config('lightning_api.settings')->get('entity_json');
+
+  if ($entity->getEntityType()->getBundleOf() && $allowed) {
+    \Drupal::service('router.builder')->setRebuildNeeded();
+  }
+}
+
 function lightning_api_entity_json(EntityInterface $entity) {
-  $allowed = \Drupal::config('lightning_api.settings')
-    ->get('entity_json');
+  $allowed = \Drupal::config('lightning_api.settings')->get('entity_json');
 
   $uuid = $entity->uuid();
 
@@ -47,12 +58,22 @@ function lightning_api_entity_json(EntityInterface $entity) {
     );
 
   if ($allowed && $uuid && $resource_type) {
-    return Url::fromRoute(
-      'jsonapi.' . $resource_type->getTypeName() . '.individual',
-      [
+    $route = 'jsonapi.' . $resource_type->getTypeName() . '.individual';
+
+    // JSON API routes are built dynamically per entity bundle. If for whatever
+    // reason the appropriate route does not exist yet, fail silently.
+    // @see lightning_api_entity_insert().
+    try {
+      \Drupal::service('router.route_provider')->getRouteByName($route);
+
+      return Url::fromRoute($route, [
         $resource_type->getEntityTypeId() => $uuid,
-      ]
-    );
+      ]);
+    }
+    catch (RouteNotFoundException $e) {
+      // No worries. The route will probably be built soon, most likely during
+      // the next general cache rebuild.
+    }
   }
 }
 

--- a/modules/lightning_features/lightning_api/lightning_api.routing.yml
+++ b/modules/lightning_features/lightning_api/lightning_api.routing.yml
@@ -1,0 +1,7 @@
+lightning_api.settings:
+  path: '/admin/config/system/lightning/api'
+  defaults:
+    _title: Lightning
+    _form: '\Drupal\lightning_api\Form\SettingsForm'
+  requirements:
+    _is_administrator: 'true'

--- a/modules/lightning_features/lightning_api/src/Form/SettingsForm.php
+++ b/modules/lightning_features/lightning_api/src/Form/SettingsForm.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Drupal\lightning_api\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * The settings form for controlling Content API's behavior.
+ */
+class SettingsForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return ['lightning_api.settings'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'lightning_api_settings_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form['entity_json'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Expose a "View JSON" link in entity operations'),
+      '#default_value' => $this->config('lightning_api.settings')->get('entity_json'),
+    ];
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->config('lightning_api.settings')
+      ->set('entity_json', (bool) $form_state->getValue('entity_json'))
+      ->save();
+
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/modules/lightning_features/lightning_core/modules/lightning_dev/lightning_dev.install
+++ b/modules/lightning_features/lightning_core/modules/lightning_dev/lightning_dev.install
@@ -50,6 +50,11 @@ function lightning_dev_install() {
   $widgets['8b142f33-59d1-47b1-9e3a-4ae85d8376fa']['label'] = 'Create embed';
   $entity_browser->set('widgets', $widgets);
   $entity_browser->save();
+
+  \Drupal::configFactory()
+    ->getEditable('lightning_api.settings')
+    ->set('entity_json', TRUE)
+    ->save();
 }
 
 /**

--- a/modules/lightning_features/lightning_core/modules/lightning_dev/lightning_dev.install
+++ b/modules/lightning_features/lightning_core/modules/lightning_dev/lightning_dev.install
@@ -232,4 +232,9 @@ function lightning_dev_update_8007() {
   $installer = \Drupal::service('module_installer');
   $installer->uninstall(['page_manager']);
   $installer->install(['lightning_api']);
+
+  \Drupal::configFactory()
+    ->getEditable('lightning_api.settings')
+    ->set('entity_json', TRUE)
+    ->save();
 }

--- a/tests/config/lightning_api.settings.yml
+++ b/tests/config/lightning_api.settings.yml
@@ -1,0 +1,1 @@
+entity_json: true

--- a/tests/features/api.feature
+++ b/tests/features/api.feature
@@ -1,0 +1,26 @@
+@lightning @api
+Feature: JSON API for decoupled applications
+
+  @23138ee5
+  Scenario: Viewing a content entity as JSON
+    Given I am logged in as a user with the administrator role
+    And page content:
+      | title  |
+      | Foobar |
+    When I visit "/admin/content"
+    And I click "View JSON"
+    Then the response status code should be 200
+
+  @160f8533
+  Scenario Outline: Viewing a config entity as JSON
+    Given I am logged in as a user with the administrator role
+    When I visit "<url>"
+    And I click "View JSON"
+    Then the response status code should be 200
+
+    Examples:
+      | url                      |
+      | /admin/structure/contact |
+      | /admin/structure/media   |
+      | /admin/structure/types   |
+      | /admin/structure/views   |

--- a/tests/src/Functional/ConfigIntegrityTest.php
+++ b/tests/src/Functional/ConfigIntegrityTest.php
@@ -123,6 +123,7 @@ class ConfigIntegrityTest extends BrowserTestBase {
     $this->assertPermissions('landing_page_reviewer', $permission);
 
     $this->assertForbidden('/admin/config/system/lightning');
+    $this->assertForbidden('/admin/config/system/lightning/api');
     $this->assertForbidden('/admin/config/system/lightning/layout');
     $this->assertForbidden('/admin/config/system/lightning/media');
 

--- a/tests/src/Functional/ConfigIntegrityTest.php
+++ b/tests/src/Functional/ConfigIntegrityTest.php
@@ -130,8 +130,10 @@ class ConfigIntegrityTest extends BrowserTestBase {
     $this->drupalLogin($account);
 
     $this->assertAllowed('/admin/config/system/lightning');
+    $assert->linkByHrefExists('/admin/config/system/lightning/api');
     $assert->linkByHrefExists('/admin/config/system/lightning/layout');
     $assert->linkByHrefExists('/admin/config/system/lightning/media');
+    $this->assertAllowed('/admin/config/system/lightning/api');
     $this->assertAllowed('/admin/config/system/lightning/layout');
     $this->assertAllowed('/admin/config/system/lightning/media');
 


### PR DESCRIPTION
This would be a useful *developer-facing* addition to Content API. Any entity that provides operations (i.e., the drop-button you see in lists) should include an operation to view that entity's JSON representation, which is really just a link to the JSON API-provided URL for that entity. Since this is developer-focused, it will be turned off by default via a config switch.