### PR TITLE
Hide API docs for bundle entities behind a config option

### DIFF
--- a/modules/lightning_features/lightning_api/config/install/lightning_api.settings.yml
+++ b/modules/lightning_features/lightning_api/config/install/lightning_api.settings.yml
@@ -1,2 +1,2 @@
 entity_json: false
-bundle_docs: true
+bundle_docs: false

--- a/modules/lightning_features/lightning_api/config/install/lightning_api.settings.yml
+++ b/modules/lightning_features/lightning_api/config/install/lightning_api.settings.yml
@@ -1,1 +1,2 @@
 entity_json: false
+bundle_docs: true

--- a/modules/lightning_features/lightning_api/config/schema/lightning_api.schema.yml
+++ b/modules/lightning_features/lightning_api/config/schema/lightning_api.schema.yml
@@ -5,3 +5,6 @@ lightning_api.settings:
     entity_json:
       type: boolean
       label: 'Expose "View JSON" link in entity operations'
+    bundle_docs:
+      type: boolean
+      label: 'Expose "View API Documentation" link in bundle entity operations'

--- a/modules/lightning_features/lightning_api/lightning_api.install
+++ b/modules/lightning_features/lightning_api/lightning_api.install
@@ -40,3 +40,13 @@ function lightning_api_install() {
     lightning_api_modules_installed(['simple_oauth']);
   }
 }
+
+/**
+ * Sets a default value for lightning_api.settings:bundle_docs.
+ */
+function lightning_api_update_8001() {
+  \Drupal::configFactory()
+    ->getEditable('lightning_api.settings')
+    ->set('bundle_docs', TRUE)
+    ->save();
+}

--- a/modules/lightning_features/lightning_api/lightning_api.module
+++ b/modules/lightning_features/lightning_api/lightning_api.module
@@ -93,7 +93,7 @@ function lightning_api_entity_operation(EntityInterface $entity) {
   }
 
   $bundle_of = $entity->getEntityType()->getBundleOf();
-  if ($bundle_of) {
+  if ($bundle_of && \Drupal::config('lightning_api.settings')->get('bundle_docs')) {
     $fragment = str_replace(' ', '-', sprintf(
       'tag/%s-%s',
       \Drupal::entityTypeManager()->getDefinition($bundle_of)->getLabel(),

--- a/modules/lightning_features/lightning_api/src/Form/SettingsForm.php
+++ b/modules/lightning_features/lightning_api/src/Form/SettingsForm.php
@@ -28,10 +28,17 @@ class SettingsForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('lightning_api.settings');
+
     $form['entity_json'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Expose a "View JSON" link in entity operations'),
-      '#default_value' => $this->config('lightning_api.settings')->get('entity_json'),
+      '#default_value' => $config->get('entity_json'),
+    ];
+    $form['bundle_docs'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Expose a "View API Documentation" link in bundle entity operations'),
+      '#default_value' => $config->get('bundle_docs'),
     ];
     return parent::buildForm($form, $form_state);
   }
@@ -42,6 +49,7 @@ class SettingsForm extends ConfigFormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $this->config('lightning_api.settings')
       ->set('entity_json', (bool) $form_state->getValue('entity_json'))
+      ->set('bundle_docs', (bool) $form_state->getValue('bundle_docs'))
       ->save();
 
     parent::submitForm($form, $form_state);


### PR DESCRIPTION
Inspired by #421 and @dgpalmer's comment, this PR adds a config option, off by default, to show the "View API documentation" operation for bundle entities; there's an update hook which will enable the value, in order to preserve the current behavior.