### PR TITLE
Show real OAuth errors when generating a key pair.

### DIFF
--- a/modules/lightning_features/lightning_api/src/OAuthHelper.php
+++ b/modules/lightning_features/lightning_api/src/OAuthHelper.php
@@ -31,13 +31,13 @@ class OAuthHelper {
       ]);
 
       if (empty($pk)) {
-        throw new \Exception($error);
+        throw new \Exception(openssl_error_string() ?: $error);
       }
 
       $key_pair[0] = NULL;
       $victory = openssl_pkey_export($pk, $key_pair[0]);
       if (empty($victory)) {
-        throw new \Exception($error);
+        throw new \Exception(openssl_error_string() ?: $error);
       }
 
       $details = openssl_pkey_get_details($pk);
@@ -45,7 +45,7 @@ class OAuthHelper {
         $key_pair[1] = $details['key'];
       }
       else {
-        throw new \Exception($error);
+        throw new \Exception(openssl_error_string() ?: $error);
       }
 
       openssl_pkey_free($pk);


### PR DESCRIPTION
If any errors are encountered when generating key pairs with Lightning's OAuthHelper, a generic error message ("An internal error occurred") is always thrown. This makes troubleshooting failures extremely difficult.

OpenSSL makes its most recent error available with the function `openssl_error_string()`(see http://php.net/manual/en/function.openssl-error-string.php), and Lightning should be presenting this message instead of the generic one, when possible.