### PR TITLE
Lock down generated OAuth key permissions

### DIFF
--- a/modules/lightning_features/lightning_api/src/OAuthHelper.php
+++ b/modules/lightning_features/lightning_api/src/OAuthHelper.php
@@ -63,6 +63,7 @@ class OAuthHelper {
     $path = sprintf('%s/%s.key', sys_get_temp_dir(), hash('sha256', $key));
 
     if (file_put_contents($path, $key)) {
+      drupal_chmod($path, 0600);
       return $path;
     }
     else {

--- a/modules/lightning_features/lightning_core/modules/lightning_dev/lightning_dev.module
+++ b/modules/lightning_features/lightning_core/modules/lightning_dev/lightning_dev.module
@@ -29,10 +29,12 @@ function lightning_dev_modules_installed(array $modules) {
 
     $key = $oauth_settings->get('public_key');
     $key = file_unmanaged_move($key, '/tmp/simple_oauth.public.key', FILE_EXISTS_REPLACE);
+    drupal_chmod($key, 0600);
     $oauth_settings->set('public_key', $key);
 
     $key = $oauth_settings->get('private_key');
     $key = file_unmanaged_move($key, '/tmp/simple_oauth.private.key', FILE_EXISTS_REPLACE);
+    drupal_chmod($key, 0600);
     $oauth_settings->set('private_key', $key);
 
     $oauth_settings->save();

--- a/tests/src/Functional/ConfigIntegrityTest.php
+++ b/tests/src/Functional/ConfigIntegrityTest.php
@@ -131,11 +131,11 @@ class ConfigIntegrityTest extends BrowserTestBase {
 
     $private_key = $oauth->get('private_key');
     $this->assertNotEmpty($private_key);
-    $this->assertFileExists($private_key);
+    $this->assertFilePermissions(0600, $private_key);
 
     $public_key = $oauth->get('public_key');
     $this->assertNotEmpty($public_key);
-    $this->assertFileExists($public_key);
+    $this->assertFilePermissions(0600, $public_key);
   }
 
   /**
@@ -227,6 +227,19 @@ class ConfigIntegrityTest extends BrowserTestBase {
   protected function assertForbidden($path) {
     $this->drupalGet($path);
     $this->assertSession()->statusCodeEquals(403);
+  }
+
+  /**
+   * Asserts that a file exists and has a specific permission mask.
+   *
+   * @param int $permissions
+   *   The permission mask as an octal number (0755, 0600, etc.)
+   * @param string $file
+   *   The path to the file.
+   */
+  protected function assertFilePermissions($permissions, $file) {
+    $this->assertFileExists($file);
+    $this->assertSame($permissions, fileperms($file) & 0777);
   }
 
   /**


### PR DESCRIPTION
I love the fact that this security-related PR addresses #443, which is the SSL port number. All this does is set 600 (very restrictive) permissions on the generated keys. Also added tests to assert this.