### PR TITLE
Don't include drush in nightly build artifacts

### DIFF
--- a/acquia-pipelines.yml
+++ b/acquia-pipelines.yml
@@ -2,9 +2,11 @@
 # Lightning and runs its functional tests. Upon success, an artifact is deployed
 # to the lightningnightly (92170259-5e36-4052-a2ad-0dd5ee5b3ec2) sub on Acquia
 # cloud.
-version: 1.0.0
+version: 1.1.0
 services:
   - mysql
+  - php:
+      version: 7.1
 
 events:
   build:

--- a/acquia-pipelines.yml
+++ b/acquia-pipelines.yml
@@ -35,12 +35,7 @@ events:
           type: script
           script:
             - cd $SOURCE_DIR
-            # Move phing into require section so we still have it to manipulate
-            # the settings file after we build artifact.
-            - composer require phing/phing:^2.14
-            - phing destroy
-            # Install with no dev so that our version of Drush doesn't interfere
-            # with cloud.
-            - composer install --no-dev
+            # Remove drush so our version doesn't interfere with cloud commands.
+            - composer remove drush/drush --dev
             # Setup settings file and codebase with minimum required for cloud.
-            - ./bin/phing cloud-settings
+            - phing cloud-settings

--- a/acquia-pipelines.yml
+++ b/acquia-pipelines.yml
@@ -34,6 +34,13 @@ events:
       - cleanup:
           type: script
           script:
-            # Setup settings file and codebase with minimum required for cloud.
             - cd $SOURCE_DIR
-            - phing cloud-settings
+            # Move phing into require section so we still have it to manipulate
+            # the settings file after we build artifact.
+            - composer require phing/phing:^2.14
+            - phing destroy
+            # Install with no dev so that our version of Drush doesn't interfere
+            # with cloud.
+            - composer install --no-dev
+            # Setup settings file and codebase with minimum required for cloud.
+            - ./bin/phing cloud-settings


### PR DESCRIPTION
When Lightning updated it's dev dependency to drush9, it conflicted with some scripts on cloud that assumed drush8 was present. Removing drush from the artifact will force cloud to use its global version of drush.