### PR TITLE
Require "Document" field on "Document" media bundle

### DIFF
--- a/modules/lightning_features/lightning_media/modules/lightning_media_document/config/install/field.field.media.document.field_document.yml
+++ b/modules/lightning_features/lightning_media/modules/lightning_media_document/config/install/field.field.media.document.field_document.yml
@@ -12,7 +12,7 @@ entity_type: media
 bundle: document
 label: Document
 description: ''
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''


### PR DESCRIPTION
Shouldn't the "Document" field on the "Document" media bundle be required? It hardly makes sense to create a media entity without a file, and all the other file fields on media bundles are required.