### PR TITLE
Install Composer dependences in docroot

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
       "lightning-subprofile"
     ],
     "config": {
-        "bin-dir": "bin/"
+        "bin-dir": "bin/",
+        "vendor-dir": "docroot/vendor/"
     },
     "repositories": [
         {
@@ -61,7 +62,7 @@
         "release-version": "Acquia\\Lightning\\Composer\\ReleaseVersion::execute",
         "verify-patched-constraints": "Acquia\\Lightning\\Composer\\PatchedConstraint::execute",
         "enable-asset-packagist": "Acquia\\Lightning\\Composer\\AssetPackagist::execute",
-        "nuke": "rm -r -f bin docroot vendor"
+        "nuke": "rm -r -f bin docroot"
     },
     "extra": {
         "installer-types": [


### PR DESCRIPTION
This will make it easier to generate tarballs for use by Cloud. It doesn't affect our local build (as evidenced by the passing test suite on my branch), so I see no real reason not to do this.