### PR TITLE
Require composer patches 1.6.3.

### DIFF
--- a/acquia-pipelines.yml
+++ b/acquia-pipelines.yml
@@ -17,6 +17,8 @@ events:
             # Add Composer's local bin directory to the PATH so that we will be
             # running our installed versions of Drush, PHPCS, Behat, etc.
             - export PATH="$HOME/.composer/vendor/bin:$SOURCE_DIR/bin:$PATH"
+            - git --version
+            - patch --version
             - composer validate --no-check-all --ansi --no-interaction
             - composer install
       - install:

--- a/acquia-pipelines.yml
+++ b/acquia-pipelines.yml
@@ -20,7 +20,7 @@ events:
             - git --version
             - patch --version
             - composer validate --no-check-all --ansi --no-interaction
-            - composer install
+            - composer install -vvv
       - install:
           type: script
           script:

--- a/composer.json
+++ b/composer.json
@@ -163,7 +163,7 @@
         }
     },
     "require": {
-        "cweagans/composer-patches": "^1.5.0",
+        "cweagans/composer-patches": "^1.6.3",
         "drupal/core": "~8.4.1",
         "drupal/embed": "^1.0",
         "drupal/entity_embed": "1.0.0-beta2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "23258c87844cd7d6f5ef3348449bcb87",
+    "content-hash": "2942166940e9ebf75878eb5b4197546d",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -330,16 +330,16 @@
         },
         {
             "name": "cweagans/composer-patches",
-            "version": "1.6.2",
+            "version": "1.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cweagans/composer-patches.git",
-                "reference": "014e968ca2ce4342476b3f2f6779b274fff8ae9e"
+                "reference": "730f0f620845974764a91482ac936cc6f39da184"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/014e968ca2ce4342476b3f2f6779b274fff8ae9e",
-                "reference": "014e968ca2ce4342476b3f2f6779b274fff8ae9e",
+                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/730f0f620845974764a91482ac936cc6f39da184",
+                "reference": "730f0f620845974764a91482ac936cc6f39da184",
                 "shasum": ""
             },
             "require": {
@@ -370,7 +370,7 @@
                 }
             ],
             "description": "Provides a way to patch Composer packages.",
-            "time": "2017-08-30T16:41:23+00:00"
+            "time": "2017-11-22T20:18:27+00:00"
         },
         {
             "name": "defuse/php-encryption",
@@ -902,7 +902,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.13",
-                    "datestamp": "1502799051",
+                    "datestamp": "1511982786",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -3397,7 +3397,7 @@
                 },
                 "drupal": {
                     "version": "8.x-3.0",
-                    "datestamp": "1506893943",
+                    "datestamp": "1511480585",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -7919,8 +7919,7 @@
             "homepage": "https://www.drupal.org/project/media_entity_generic",
             "support": {
                 "source": "http://cgit.drupalcode.org/media_entity_generic"
-            },
-            "time": "2017-10-18T07:13:43+00:00"
+            }
         },
         {
             "name": "drush/drush",


### PR DESCRIPTION
Composer patches 1.6.3 was [just released](https://github.com/cweagans/composer-patches/releases/tag/1.6.3), which fixes [this pernicious bug](https://docs.acquia.com/article/fixing-failing-composer-patches-updating-gnu-patch), regardless of peoples' git/patch versions.

I think it would be good to require this new version. BLT is doing the same.