### PR TITLE
Make ComponentDiscovery more flexible

### DIFF
--- a/src/ComponentDiscovery.php
+++ b/src/ComponentDiscovery.php
@@ -4,7 +4,6 @@ namespace Drupal\lightning;
 
 use Drupal\Core\Extension\Extension;
 use Drupal\Core\Extension\ExtensionDiscovery;
-use Drupal\field\Tests\reEnableModuleFieldTest;
 
 /**
  * Helper object to locate Lightning components and sub-components.

--- a/src/ComponentDiscovery.php
+++ b/src/ComponentDiscovery.php
@@ -11,6 +11,11 @@ use Drupal\Core\Extension\ExtensionDiscovery;
 class ComponentDiscovery {
 
   /**
+   * Prefix that Lightning components are expected to start with.
+   */
+  const COMPONENT_PREFIX = 'lightning_';
+
+  /**
    * The extension discovery iterator.
    *
    * @var \Drupal\Core\Extension\ExtensionDiscovery
@@ -70,7 +75,7 @@ class ComponentDiscovery {
    */
   public function getAll() {
     if (is_null($this->components)) {
-      $identifier = 'lightning_';
+      $identifier = self::COMPONENT_PREFIX;
 
       $filter = function (Extension $module) use ($identifier) {
         return strpos($module->getName(), $identifier) === 0;
@@ -88,7 +93,7 @@ class ComponentDiscovery {
    *   Array of extension objects for top-level Lightning components.
    */
   public function getMainComponents() {
-    $identifier = 'lightning_';
+    $identifier = self::COMPONENT_PREFIX;
 
     $filter = function (Extension $module) use ($identifier) {
       // Assumes that:
@@ -96,7 +101,7 @@ class ComponentDiscovery {
       //    main component.
       // 2. The main component's directory starts with "lightning_".
       // E.g.: "/lightning_core/modules/lightning_search".
-      $path = explode('/', $module->getPath());
+      $path = explode(DIRECTORY_SEPARATOR, $module->getPath());
       $parent = $path[count($path)-3];
       return strpos($parent, $identifier) !== 0;
     };

--- a/tests/src/Kernel/ComponentDiscoveryTest.php
+++ b/tests/src/Kernel/ComponentDiscoveryTest.php
@@ -40,6 +40,8 @@ class ComponentDiscoveryTest extends KernelTestBase {
     $this->assertInstanceOf(Extension::class, $components['lightning_core']);
     $this->assertInstanceOf(Extension::class, $components['lightning_search']);
     $this->assertInstanceOf(Extension::class, $components['lightning_dev']);
+    $this->assertArrayNotHasKey('panels', $components);
+    $this->assertArrayNotHasKey('views', $components);
   }
 
   /**


### PR DESCRIPTION
This PR allows Lightning ComponentDiscovery to work even if Lightning Components aren't inside the profile. So ComponentDiscovery will continue to work when Lightning Components are intermingled with other extensions.

It also adds a couple assertions that make sure other contrib and core modules aren't accidentally included.