### PR TITLE
Add package and datestamp to profile info file

### DIFF
--- a/lightning.info.yml
+++ b/lightning.info.yml
@@ -57,3 +57,5 @@ dependencies:
 themes:
   - bartik
   - seven
+project: lightning
+datestamp: '1513190900'

--- a/lightning.info.yml
+++ b/lightning.info.yml
@@ -58,4 +58,4 @@ themes:
   - bartik
   - seven
 project: lightning
-datestamp: '1513190900'
+datestamp: '1513262037'

--- a/src/Composer/ReleaseVersion.php
+++ b/src/Composer/ReleaseVersion.php
@@ -28,13 +28,13 @@ class ReleaseVersion {
     $finder = (new Finder())
       ->name('*.info.yml')
       ->in('.')
-      ->exclude('docroot');
+      ->exclude(['docroot', 'vendor']);
 
     /** @var \Symfony\Component\Finder\SplFileInfo $info_file */
     foreach ($finder as $info_file) {
       $info = Yaml::parse($info_file->getContents());
 
-      if (@$info['name'] == 'Lightning' && $info['type'] == 'profile') {
+      if ($info['name'] == 'Lightning' && $info['type'] == 'profile') {
         $info['datestamp'] = date('U');
       }
       // Wrapping the version number in << and >> will cause the dumper to quote

--- a/src/Composer/ReleaseVersion.php
+++ b/src/Composer/ReleaseVersion.php
@@ -34,6 +34,9 @@ class ReleaseVersion {
     foreach ($finder as $info_file) {
       $info = Yaml::parse($info_file->getContents());
 
+      if (@$info['name'] == 'Lightning' && $info['type'] == 'profile') {
+        $info['datestamp'] = date('U');
+      }
       // Wrapping the version number in << and >> will cause the dumper to quote
       // the string, which is necessary for compliance with the strict PECL
       // parser.


### PR DESCRIPTION
Given:

1. We don't think composer-built Lightning installs are getting properly added to the reported installs
2. There are two additional keys in the D.O-packaged info file

Let's just add those two keys.