### PR TITLE
Add Console command that returns current version of Lightning

### DIFF
--- a/lightning.services.yml
+++ b/lightning.services.yml
@@ -45,7 +45,7 @@ services:
     tags:
       - { name: drupal.generator }
 
-  lightning.lightning_version:
+  lightning.version_command:
     class: 'Drupal\lightning\Command\VersionCommand'
     arguments:
             - '@app.root'

--- a/lightning.services.yml
+++ b/lightning.services.yml
@@ -44,3 +44,10 @@ services:
     arguments: []
     tags:
       - { name: drupal.generator }
+
+  lightning.lightning_version:
+    class: 'Drupal\lightning\Command\VersionCommand'
+    arguments:
+            - '@app.root'
+    tags:
+      - { name: drupal.command }

--- a/lightning.services.yml
+++ b/lightning.services.yml
@@ -48,6 +48,6 @@ services:
   lightning.version_command:
     class: 'Drupal\lightning\Command\VersionCommand'
     arguments:
-            - '@app.root'
+      - '@app.root'
     tags:
       - { name: drupal.command }

--- a/src/Command/VersionCommand.php
+++ b/src/Command/VersionCommand.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\lightning\Command;
 
-use Drupal\Console\Core\Command\ContainerAwareCommand;
+use Drupal\Console\Core\Command\Command;
 use Drupal\Console\Core\Style\DrupalStyle;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -15,7 +15,7 @@ use Drupal\Console\Annotations\DrupalCommand;
  *
  * @DrupalCommand
  */
-class VersionCommand extends ContainerAwareCommand {
+class VersionCommand extends Command {
 
   /**
    * The Drupal application root.

--- a/src/Command/VersionCommand.php
+++ b/src/Command/VersionCommand.php
@@ -77,14 +77,17 @@ class VersionCommand extends ContainerAwareCommand {
    * NOTE: This will break if the minor version number is greater than 9.
    *
    * @param $drupal_version
-   *   The version in 8.x-n.n format.
+   *   The version in 8.x-n.nn format.
    *
    * @return string
    *   Semantic version
    */
   public static function toSemanticVersion($drupal_version) {
     preg_match('/^8\.x-(\d+).(\d)(\d+)(-.+)?$/', $drupal_version, $matches);
-    $semver = "$matches[1].$matches[2]." . intval($matches[3]) . $matches[4];
+    $semver = "$matches[1].$matches[2]." . intval($matches[3]);
+    if (isset($matches[4])) {
+      $semver = $semver .$matches[4];
+    }
     return $semver;
   }
 

--- a/src/Command/VersionCommand.php
+++ b/src/Command/VersionCommand.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Drupal\lightning\Command;
+
+use Drupal\Console\Core\Command\ContainerAwareCommand;
+use Drupal\Console\Core\Style\DrupalStyle;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Yaml\Yaml;
+use Drupal\Console\Annotations\DrupalCommand;
+
+/**
+ * Class VersionCommand.
+ *
+ * @DrupalCommand
+ */
+class VersionCommand extends ContainerAwareCommand {
+
+  /**
+   * The Drupal application root.
+   *
+   * @var string
+   */
+  protected $appRoot;
+
+  /**
+   * VersionCommand constructor.
+   *
+   * @param string $app_root
+   *   The Drupal application root.
+   */
+  public function __construct($app_root) {
+    parent::__construct('lightning:version');
+    $this->appRoot = $app_root;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function configure() {
+    $this->setName('lightning:version');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    $finder = (new Finder())
+      ->files()
+      ->name('lightning.info.yml')
+      ->in($this->appRoot . '/profiles');
+
+    foreach ($finder as $info_file) {
+      $info = Yaml::parse($info_file->getContents());
+      if (($info['distribution']['name'] == 'Lightning') && isset($info['version'])) {
+        // There should only be one file in docroot/profiles named
+        // lightning.info.yml, but just to make sure we have the right file in
+        // the iterator, break out when we have enough information to be
+        // reasonably confident.
+        break;
+      }
+    }
+
+    $io = new DrupalStyle($input, $output);
+    $io->info($this->toSemanticVersion($info['version']));
+  }
+
+  /**
+   * Converts a Lightning release version to a semantic version number according
+   * to Lightning's VERSIONS.md file. Examples:
+   * - 8.x-1.23 => 1.2.3
+   * - 8.x-1.203 => 1.2.3
+   * - 8.x-1.230 => 1.2.30
+   * - 8.x-1.23-dev => 8.x-1.2.3-dev
+   *
+   * NOTE: This will break if the minor version number is greater than 9.
+   *
+   * @param $drupal_version
+   *   The version in 8.x-n.n format.
+   *
+   * @return string
+   *   Semantic version
+   */
+  public static function toSemanticVersion($drupal_version) {
+    preg_match('/^8\.x-(\d+).(\d)(\d+)(-.+)?$/', $drupal_version, $matches);
+    $semver = "$matches[1].$matches[2]." . intval($matches[3]) . $matches[4];
+    return $semver;
+  }
+
+}

--- a/tests/src/Kernel/VersionCommandTest.php
+++ b/tests/src/Kernel/VersionCommandTest.php
@@ -25,7 +25,7 @@ class VersionCommandTest extends KernelTestBase {
 
     foreach ($drupal_versions as $drupal_version => $expected_semantic_version) {
       $generated_semantic_version = VersionCommand::toSemanticVersion($drupal_version);
-      $this->assertEquals($expected_semantic_version, $generated_semantic_version);
+      $this->assertSame($expected_semantic_version, $generated_semantic_version);
     }
   }
 

--- a/tests/src/Kernel/VersionCommandTest.php
+++ b/tests/src/Kernel/VersionCommandTest.php
@@ -5,6 +5,11 @@ namespace Drupal\Tests\lightning\Kernel;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\lightning\Command\VersionCommand;
 
+/**
+ * @group lightning
+ *
+ * @coversDefaultClass \Drupal\lightning\Command\VersionCommand
+ */
 class VersionCommandTest extends KernelTestBase {
 
   /**

--- a/tests/src/Kernel/VersionCommandTest.php
+++ b/tests/src/Kernel/VersionCommandTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\Tests\lightning\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\lightning\Command\VersionCommand;
+
+class VersionCommandTest extends KernelTestBase {
+
+  /**
+   * @covers ::toSemanticVersion
+   */
+  public function testToSemanticVersion() {
+    $drupal_versions = [
+      '8.x-1.23' => '1.2.3',
+      '8.x-1.203' => '1.2.3',
+      '8.x-1.230' => '1.2.30',
+      '8.x-1.23-dev' => '1.2.3-dev',
+    ];
+
+    foreach ($drupal_versions as $drupal_version => $expected_semantic_version) {
+      $generated_semantic_version = VersionCommand::toSemanticVersion($drupal_version);
+      $this->assertEquals($expected_semantic_version, $generated_semantic_version);
+    }
+  }
+
+}


### PR DESCRIPTION
We need this information in Lightning Project's CI for the "since" argument in our update-to-HEAD tests.