### PR TITLE
Run CI tests from exported config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ install:
   # Build the Lightning code base with the latest dependencies.
   - composer update
   # Install Lightning cleanly so that settings.php will be created properly.
-  - lightning install 'mysql\://lightning:lightning@127.0.0.1/drupal' lightning 'http://127.0.0.1:8080'
+  - lightning install --from-config 'mysql\://lightning:lightning@127.0.0.1/drupal' lightning 'http://127.0.0.1:8080'
   # Restore and update from the previous version.
   - lightning update $VERSION
 


### PR DESCRIPTION
Lightning and its components are now (supposed to be) compatible with the Config Installer profile. However, we don't test this on CI in any way. @balsama and I agreed to use a new workflow for CI testing -- install Lightning, export config, reinstall on top of the Config Installer profile, and run tests. This should allow us to catch config-related bugs quite easily.