### PR TITLE
Avoid deprecated usage of user property

### DIFF
--- a/tests/features/bootstrap/entity.behat.inc
+++ b/tests/features/bootstrap/entity.behat.inc
@@ -74,7 +74,7 @@ class EntitySubContext extends DrupalSubContextBase {
     $node = $scope->getEntity();
 
     if (!isset($node->uid)) {
-      $user = $this->getContext(DrupalContext::class)->user;
+      $user = $this->getContext(DrupalContext::class)->getUserManager()->getCurrentUser();
 
       if (is_object($user)) {
         $node->uid = $user->uid;


### PR DESCRIPTION
This change avoids the deprecation error generated here: https://github.com/jhedstrom/drupalextension/blob/master/src/Drupal/DrupalExtension/Context/RawDrupalContext.php#L173