### PR TITLE
Remove symlinks previously used for testing

### DIFF
--- a/modules/upload_bundles_test
+++ b/modules/upload_bundles_test
@@ -1,1 +1,0 @@
-../tests/modules/upload_bundles_test

--- a/modules/view_mode_test
+++ b/modules/view_mode_test
@@ -1,1 +1,0 @@
-../tests/modules/view_mode_test


### PR DESCRIPTION
This addresses one of the complaints in https://www.drupal.org/project/lightning/issues/2953576 -- the UNIX symlinks in Lightning (created aeons ago for testing purposes) break installations on Windows. The tests no longer use these symlinks at all, so we can remove them entirely.