### PR TITLE
Fix exposed filter name in documentation

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -167,8 +167,7 @@ follow the instructions for updating from 2.2.0 to 2.2.1, then from 2.2.1 to
 
 ### 3.0.3 to 3.1.0
 * Edit the **Media** view, and if it has an exposed filter called "Media Type",
-  modify the filter label to "Type" from "Provider", and change its URL
-  identifier to "type" from "provider".
+  modify the filter label to "Type" and change its URL identifier to "type".
 
 ### 3.0.2 to 3.0.3
 There are no manual update steps for this version.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -168,7 +168,7 @@ follow the instructions for updating from 2.2.0 to 2.2.1, then from 2.2.1 to
 ### 3.0.3 to 3.1.0
 * Edit the **Media** view, and if it has an exposed filter called "Media Type",
   modify the filter label to "Type" from "Provider", and change its URL
-  identifier to “type” from "provider".
+  identifier to "type" from "provider".
 
 ### 3.0.2 to 3.0.3
 There are no manual update steps for this version.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -166,9 +166,9 @@ follow the instructions for updating from 2.2.0 to 2.2.1, then from 2.2.1 to
 2.2.2, in that order.
 
 ### 3.0.3 to 3.1.0
-* Edit the **Media** view, and if it has an exposed filter called “Media Type”,
-  modify the filter label to “Type” from “Provider”, and change its URL
-  identifier to “type” from “provider”.
+* Edit the **Media** view, and if it has an exposed filter called "Media Type",
+  modify the filter label to "Type" from "Provider", and change its URL
+  identifier to “type” from "provider".
 
 ### 3.0.2 to 3.0.3
 There are no manual update steps for this version.

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -166,8 +166,9 @@ follow the instructions for updating from 2.2.0 to 2.2.1, then from 2.2.1 to
 2.2.2, in that order.
 
 ### 3.0.3 to 3.1.0
-* Edit the **Media** view, and if it has an exposed filter called "Source",
-  rename that filter to "Type", and change its URL identifier to "type".
+* Edit the **Media** view, and if it has an exposed filter called “Media Type”,
+  modify the filter label to “Type” from “Provider”, and change its URL
+  identifier to “type” from “provider”.
 
 ### 3.0.2 to 3.0.3
 There are no manual update steps for this version.


### PR DESCRIPTION
According to @malikkotob, the manual update instructions for Lightning Media are misleading. The filter name is actually "Media Type", the label is "Provider", and we want to change it to "Type".

It'd be good to confirm this by installing 3.0.3 before merging. And we should have a parallel PR against Lightning Media to change the annotation on Update200.php.