### PR TITLE
Never include commit hash in core makefile

### DIFF
--- a/build-lightning.make
+++ b/build-lightning.make
@@ -3,5 +3,4 @@ core = 8.x
 includes[] = drupal-org-core.make
 projects[lightning][type] = profile
 projects[lightning][download][type] = git
-projects[lightning][download][branch] = 8.x-2.x
-projects[lightning][download][tag] = 8.x-3.x-dev
+projects[lightning][download][branch] = 8.x-3.x

--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -4,7 +4,6 @@ projects[drupal][type] = core
 projects[drupal][download][type] = git
 projects[drupal][download][url] = https://git.drupal.org/project/drupal.git
 projects[drupal][download][branch] = 8.5.x
-projects[drupal][download][revision] = 4edba21dd2be8cb9f521eb28a6a12a947df79635
 projects[drupal][patch][] = https://www.drupal.org/files/issues/1356278-408--8.5.x-real.patch
 projects[drupal][patch][] = https://www.drupal.org/files/issues/2880374-remove-experimental-warnings-6.patch
 projects[drupal][patch][] = https://www.drupal.org/files/issues/2869592-remove-update-warning-7.patch

--- a/src/Composer/Package.php
+++ b/src/Composer/Package.php
@@ -172,7 +172,16 @@ class Package {
         ['.x', NULL],
         $package['version']
       );
-      $info['download']['revision'] = $package['source']['reference'];
+
+      // We never want to specify a commit hash, regardless of whether this is
+      // a dev branch or tagged release.
+      unset($info['download']['revision']);
+
+      // But, if it is a tagged release (i.e., there's no -dev suffix in the
+      // version), we do want to specify that tag.
+      if (strpos($package['version'], '-dev') === FALSE) {
+        $info['download']['tag'] = $package['version'];
+      }
     }
     // Dev versions should use git branch + revision, otherwise a tag is used.
     elseif (strstr($package['version'], 'dev')) {


### PR DESCRIPTION
drupal.org threw another damnèd error while trying to package up our dev tarball:

```
Build for /tmp/drush_tmp_1522937587_5ac62ef3ab0f4/lightning/drupal-org-core.make failed:
Unable to checkout revision 4edba21dd2be8cb9f521eb28a6a12a947df79635
Unable to patch drupal with 1356278-408--8.5.x-real.patch.
Unable to patch drupal with 2877383-56.patch.
Unable to patch drupal with 2670730-81-89-8.5.0-rc1.patch.
```

This is because we are including the commit hash in the core makefile, which doesn't work given the nature of the subtree split for Packagist.

The solution is, when we're using a dev branch of core (8.5.x) to chase HEAD, to simply...not specify a revision. Only when using a tagged release should we specify a tag.

I tested this manually and confirmed that when a tag is specified for core, that version is checked out. If no tag is specified, then it grabs HEAD of the specified branch.