### PR TITLE
Remove start Phantom from Pipelines instructions

### DIFF
--- a/acquia-pipelines.yml
+++ b/acquia-pipelines.yml
@@ -32,7 +32,7 @@ events:
             - drush runserver --default-server=builtin 8080 &>/dev/null &
             - sleep 10
             - cd $SOURCE_DIR
-            #- behat --stop-on-failure --config .behat.yml --tags=~javascript
+            - behat --stop-on-failure --config .behat.yml --tags=~javascript
       - cleanup:
           type: script
           script:

--- a/acquia-pipelines.yml
+++ b/acquia-pipelines.yml
@@ -41,4 +41,4 @@ events:
             - lightning configure:cloud
             # Alias Drush 8.x to be compatible with Cloud.
             - composer require drush/drush:"8.1.16 as 9.2.1" --no-update
-            - composer update drush/drush --with-all-dependencies
+            - composer update drush/drush --with-dependencies

--- a/acquia-pipelines.yml
+++ b/acquia-pipelines.yml
@@ -32,12 +32,13 @@ events:
             - drush runserver --default-server=builtin 8080 &>/dev/null &
             - sleep 10
             - cd $SOURCE_DIR
-            - behat --stop-on-failure --config .behat.yml --tags=~javascript
+            #- behat --stop-on-failure --config .behat.yml --tags=~javascript
       - cleanup:
           type: script
           script:
             - cd $SOURCE_DIR
             # Setup settings file and codebase with minimum required for cloud.
             - lightning configure:cloud
-            # Remove dev tools from the Cloud build.
-            - composer remove acquia/lightning_dev --dev
+            # Alias Drush 8.x to be compatible with Cloud.
+            - composer require drush/drush:"8.1.16 as 9.2.1" --no-update
+            - composer update drush/drush --with-all-dependencies

--- a/acquia-pipelines.yml
+++ b/acquia-pipelines.yml
@@ -30,7 +30,6 @@ events:
           script:
             - cd $SOURCE_DIR/docroot
             - drush runserver --default-server=builtin 8080 &>/dev/null &
-            - phantomjs --webdriver=4444 > /dev/null &
             - sleep 10
             - cd $SOURCE_DIR
             - behat --stop-on-failure --config .behat.yml --tags=~javascript


### PR DESCRIPTION
Lightning dev no longer provides Phantom. And we stopped testing JavaScript on Pipelines a long time ago. We should stop trying to start it before running our tests.

This PR also includes a quicker way to get a cloud-compatible version of Drush that doesn't require nearly as much Composer renegotiation.