### PR TITLE
Rename "save to media library" field

### DIFF
--- a/tests/config/field.field.media.document.field_media_in_library.yml
+++ b/tests/config/field.field.media.document.field_media_in_library.yml
@@ -9,7 +9,7 @@ id: media.document.field_media_in_library
 field_name: field_media_in_library
 entity_type: media
 bundle: document
-label: 'Save to my media library'
+label: 'Show in media library'
 description: ''
 required: false
 translatable: true
@@ -18,6 +18,6 @@ default_value:
     value: 1
 default_value_callback: ''
 settings:
-  on_label: 'Saved to my media library'
-  off_label: 'Not in my media library'
+  on_label: 'Shown in media library'
+  off_label: 'Hidden in media library'
 field_type: boolean

--- a/tests/config/field.field.media.image.field_media_in_library.yml
+++ b/tests/config/field.field.media.image.field_media_in_library.yml
@@ -9,7 +9,7 @@ id: media.image.field_media_in_library
 field_name: field_media_in_library
 entity_type: media
 bundle: image
-label: 'Save to my media library'
+label: 'Show in media library'
 description: ''
 required: false
 translatable: false
@@ -18,6 +18,6 @@ default_value:
     value: 1
 default_value_callback: ''
 settings:
-  on_label: 'Saved to my media library'
-  off_label: 'Not in my media library'
+  on_label: 'Shown in media library'
+  off_label: 'Hidden in media library'
 field_type: boolean

--- a/tests/config/field.field.media.instagram.field_media_in_library.yml
+++ b/tests/config/field.field.media.instagram.field_media_in_library.yml
@@ -9,7 +9,7 @@ id: media.instagram.field_media_in_library
 field_name: field_media_in_library
 entity_type: media
 bundle: instagram
-label: 'Save to my media library'
+label: 'Show in media library'
 description: ''
 required: false
 translatable: false
@@ -18,6 +18,6 @@ default_value:
     value: 1
 default_value_callback: ''
 settings:
-  on_label: 'Saved to my media library'
-  off_label: 'Not in my media library'
+  on_label: 'Shown in media library'
+  off_label: 'Hidden in media library'
 field_type: boolean

--- a/tests/config/field.field.media.tweet.field_media_in_library.yml
+++ b/tests/config/field.field.media.tweet.field_media_in_library.yml
@@ -9,7 +9,7 @@ id: media.tweet.field_media_in_library
 field_name: field_media_in_library
 entity_type: media
 bundle: tweet
-label: 'Save to my media library'
+label: 'Show in media library'
 description: ''
 required: false
 translatable: false
@@ -18,6 +18,6 @@ default_value:
     value: 1
 default_value_callback: ''
 settings:
-  on_label: 'Saved to my media library'
-  off_label: 'Not in my media library'
+  on_label: 'Shown in media library'
+  off_label: 'Hidden in media library'
 field_type: boolean

--- a/tests/config/field.field.media.video.field_media_in_library.yml
+++ b/tests/config/field.field.media.video.field_media_in_library.yml
@@ -9,7 +9,7 @@ id: media.video.field_media_in_library
 field_name: field_media_in_library
 entity_type: media
 bundle: video
-label: 'Save to my media library'
+label: 'Show in media library'
 description: ''
 required: false
 translatable: true
@@ -18,6 +18,6 @@ default_value:
     value: 1
 default_value_callback: ''
 settings:
-  on_label: 'Saved to my media library'
-  off_label: 'Not in my media library'
+  on_label: 'Shown in media library'
+  off_label: 'Hidden in media library'
 field_type: boolean


### PR DESCRIPTION
Renames labels in test config files. Prerequisite: renaming labels in lightning_media first.