### PR TITLE
Do not test as many update paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ php:
 env:
   - VERSION=HEAD
   - VERSION=3.1.5
-  - VERSION=3.1.4
-  - VERSION=3.1.3
   # The final CI slot should be used to test the update path from the oldest
   # available database fixture.
   - VERSION=3.0.0


### PR DESCRIPTION
We don't need to test as many update paths as we do; it's a waste of resources, and the way our fixtures are built now guarantees that running tests from the oldest fixture proves that our update path works. As agreed in discussion with @balsama, we're going to only test the oldest fixture, most recent release, and HEAD.