### PR TITLE
Don't run profiles tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ script:
   - composer validate composer.json --no-check-all --ansi --no-interaction
   - behat --config .behat.yml --stop-on-failure
   - cd docroot
-  - phpunit --configuration ./core --group lightning,profiles
+  - phpunit --configuration ./core --group lightning
 
 after_failure:
   - drush watchdog:show --count=100 --severity=Error --extended


### PR DESCRIPTION
Patch [#1356276](https://www.drupal.org/project/drupal/issues/1356276?page=1) brings in two tests tagged with the "profiles" group.
They will fail, because Lightning is a distribution, and when a distribution is present it will automatically get selected instead of the testing profile.
The solution is to not run these tests.
