### PR TITLE
Add replace key to prevent duplicate jQuery versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,10 @@
         "acquia/lightning_dev": "dev-8.x-1.x",
         "drupal/schema_metatag": "^1.3"
     },
+    "replace": {
+        "bower-asset/jquery": "3.2.1",
+        "npm-asset/jquery": "3.2.1"
+    },
     "bin": [
         "lightning-subprofile"
     ],


### PR DESCRIPTION
Many packages in asset packagist require jQuery - either as `npm-asset/jquery ` or `bower-asset/jquery`  (or worse *both*), however `drupal/core` already provides jQuery 3.2.1. Adding a replace key prevents downloading these extra unnecessary packages.