### PR TITLE
Remove hook_install() from generated subprofiles

### DIFF
--- a/templates/profile/install.twig
+++ b/templates/profile/install.twig
@@ -4,11 +4,3 @@
  * @file
  * Install, update and uninstall hooks for the {{ profile }} subprofile.
  */
-
-/**
- * Implements hook_install().
- */
-function {{ machine_name }}_install() {
-  // Add code here perform additional site information tasks, generate sample
-  // content, etc.
-}

--- a/templates/profile/install.twig
+++ b/templates/profile/install.twig
@@ -4,3 +4,14 @@
  * @file
  * Install, update and uninstall hooks for the {{ profile }} subprofile.
  */
+
+/**
+ * Implement hook_install() here to perform additional site information tasks,
+ * generate sample content, etc.
+ *
+ * Drupal 8.6 provides the ability to install sites directly from existing
+ * config when using the core configuration management system. Note that this
+ * feature cannot be used if your install profile implements hook_install().
+ *
+ * @see https://www.drupal.org/node/2897299
+ */


### PR DESCRIPTION
Lightning doesn't have a hook_install() implementation in the base profile, I think specifically so that it will be compatible with the new D8.6 feature of installing site from existing config.

However, the subprofile template still creates a hook_install() implementation, which breaks the ability to install sites from existing config.

An example of this breaking things: https://github.com/acquia/blt/pull/3241#issuecomment-439105307