### PR TITLE
Use cloud Drush

### DIFF
--- a/acquia-pipelines.yml
+++ b/acquia-pipelines.yml
@@ -25,23 +25,9 @@ events:
             - cd $SOURCE_DIR
             - mysql -u root -proot -e 'CREATE DATABASE drupal;'
             - lightning install 'mysql\://root:root@localhost/drupal' lightning 'http://127.0.0.1:8080'
-      - test:
-          type: script
-          script:
-            - cd $SOURCE_DIR/docroot
-            - drush runserver --default-server=builtin 8080 &>/dev/null &
-            - phantomjs --webdriver=4444 > /dev/null &
-            - sleep 10
-            - cd $SOURCE_DIR
-            - behat --stop-on-failure --config .behat.yml --tags=~javascript
       - cleanup:
           type: script
           script:
             - cd $SOURCE_DIR
             # Setup settings file and codebase with minimum required for cloud.
             - lightning configure:cloud
-            # Remove the Drush binary and package so it doesn't interfere with
-            # cloud versions. Doing this the proper way with Composer can cause
-            # timeouts.
-            - rm ./vendor/bin/drush
-            - rm -rf ./vendor/drush

--- a/hooks/common/post-code-deploy/reinstall.sh
+++ b/hooks/common/post-code-deploy/reinstall.sh
@@ -8,4 +8,4 @@ site="$1"
 target_env="$2"
 
 # Fresh install of Lightning.
-drush @$site.$target_env site-install lightning --account-pass=admin --yes
+/usr/local/bin/drush9 @$site.$target_env site-install lightning --account-pass=admin --yes

--- a/hooks/common/post-code-update/reinstall.sh
+++ b/hooks/common/post-code-update/reinstall.sh
@@ -8,4 +8,4 @@ site="$1"
 target_env="$2"
 
 # Fresh install of Lightning.
-drush @$site.$target_env site-install lightning --account-pass=admin --yes
+/usr/local/bin/drush9 @$site.$target_env site-install lightning --account-pass=admin --yes


### PR DESCRIPTION
This PR makes the Cloud Hooks explicitly call the instance of Drush 9 on the server during the rebuild and removes redundant testing which is done on Travis CI.