### PR TITLE
Exclude test fixtures and other dev cruft from releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/git-hooks export-ignore
+/hooks export-ignore
+/tests export-ignore
+/.travis.yml export-ignore
+/acquia-pipelines.yml export-ignore
+/tarball.sh export-ignore


### PR DESCRIPTION
This follows the process [described here](https://madewithlove.be/gitattributes/) to exclude dev code (especially, huge test fixtures) from stable Lightning releases on Github, which should also exclude them from Packagist.

Our use case is to try to improve project creation times for ADS users (and by extension, any BLT or Lightning user).

We determined that if you were to zip up an entire Drupal / Lightning codebase into a compressed tarball, it would be about 100MB in size. 50MB of that would consist _solely of Lightning's test fixtures_ (including Lightning Workflow, Lightning API, etc...). So there's quite an opportunity for optimization here.

If this process works for the Lightning meta package, I'd love to see it extended to the other Lightning packages.