### PR TITLE
Fix pipelines

### DIFF
--- a/acquia-pipelines.yml
+++ b/acquia-pipelines.yml
@@ -25,6 +25,6 @@ events:
             # Setup settings file and codebase with minimum required for cloud.
             - chmod -R +w docroot/sites/default
             - cp docroot/sites/default/default.settings.php docroot/sites/default/settings.php
-            - echo "if (file_exists('/var/www/site-php')) { require '/var/www/site-php/datdemos/lightningnightly-settings.inc';}" >> docroot/sites/default/settings.php
+            - echo "if (file_exists('/var/www/site-php')) { require '/var/www/site-php/lightningnightly/lightningnightly-settings.inc';}" >> docroot/sites/default/settings.php
             - echo "\$config_directories['sync'] = '../config/sync';" >> docroot/sites/default/settings.php
 

--- a/acquia-pipelines.yml
+++ b/acquia-pipelines.yml
@@ -6,7 +6,7 @@ version: 1.1.0
 services:
   - mysql
   - php:
-      version: 7.1
+      version: 7.2
 
 events:
   build:
@@ -23,9 +23,11 @@ events:
           type: script
           script:
             # Setup settings file and codebase with minimum required for cloud.
-            - rm -rf ./config
-            - mkdir -p ./config/sync
-            - mkdir ./config/vcs
+            - ls -la config
+            - rm -rf config
+            - mkdir -p config/sync
+            - mkdir config/vcs
+            - ls -la config
             - chmod -R +w docroot/sites/default
             - cp docroot/sites/default/default.settings.php docroot/sites/default/settings.php
             - echo "if (file_exists('/var/www/site-php')) { require '/var/www/site-php/lightningnightly/lightningnightly-settings.inc';}" >> docroot/sites/default/settings.php

--- a/acquia-pipelines.yml
+++ b/acquia-pipelines.yml
@@ -23,9 +23,10 @@ events:
           type: script
           script:
             # Setup settings file and codebase with minimum required for cloud.
-            - mkdir ./config/sync
+            - rm -rf ./config
+            - mkdir -p ./config/sync
+            - mkdir ./config/vcs
             - chmod -R +w docroot/sites/default
             - cp docroot/sites/default/default.settings.php docroot/sites/default/settings.php
             - echo "if (file_exists('/var/www/site-php')) { require '/var/www/site-php/lightningnightly/lightningnightly-settings.inc';}" >> docroot/sites/default/settings.php
             - echo "\$config_directories['sync'] = '../config/sync';" >> docroot/sites/default/settings.php
-

--- a/acquia-pipelines.yml
+++ b/acquia-pipelines.yml
@@ -23,6 +23,7 @@ events:
           type: script
           script:
             # Setup settings file and codebase with minimum required for cloud.
+            - mkdir ./config/sync
             - chmod -R +w docroot/sites/default
             - cp docroot/sites/default/default.settings.php docroot/sites/default/settings.php
             - echo "if (file_exists('/var/www/site-php')) { require '/var/www/site-php/lightningnightly/lightningnightly-settings.inc';}" >> docroot/sites/default/settings.php

--- a/acquia-pipelines.yml
+++ b/acquia-pipelines.yml
@@ -27,6 +27,6 @@ events:
             - cp docroot/sites/default/default.settings.php docroot/sites/default/settings.php
             - echo "if (file_exists('/var/www/site-php')) { require '/var/www/site-php/lightningnightly/lightningnightly-settings.inc';}" >> docroot/sites/default/settings.php
             # Clear any config directories that Cloud tries to set in th include file.
-            - echo "\$config_directories = [];
+            - echo "\$config_directories = [];" >> docroot/sites/default/settings.php
             # Use the existing `config` directory we already have.
             - echo "\$config_directories['sync'] = '../config';" >> docroot/sites/default/settings.php

--- a/acquia-pipelines.yml
+++ b/acquia-pipelines.yml
@@ -26,7 +26,12 @@ events:
             - chmod -R +w docroot/sites/default
             - cp docroot/sites/default/default.settings.php docroot/sites/default/settings.php
             - echo "if (file_exists('/var/www/site-php')) { require '/var/www/site-php/lightningnightly/lightningnightly-settings.inc';}" >> docroot/sites/default/settings.php
-            # Clear any config directories that Cloud tries to set in th include file.
+            # Clear any config directories that Cloud tries to set in th include
+            # file.
             - echo "\$config_directories = [];" >> docroot/sites/default/settings.php
-            # Use the existing `config` directory we already have.
+            # Use the existing `config` directory we already have. Cloud get's
+            # confused because we have a config directory above docroot already
+            # and manipulating it in Pipelines doesn't seem to work. This
+            # deployment is ephemeral, so using the existing config directory
+            # isn't a problem.
             - echo "\$config_directories['sync'] = '../config';" >> docroot/sites/default/settings.php

--- a/acquia-pipelines.yml
+++ b/acquia-pipelines.yml
@@ -26,3 +26,7 @@ events:
             - chmod -R +w docroot/sites/default
             - cp docroot/sites/default/default.settings.php docroot/sites/default/settings.php
             - echo "if (file_exists('/var/www/site-php')) { require '/var/www/site-php/lightningnightly/lightningnightly-settings.inc';}" >> docroot/sites/default/settings.php
+            # Clear any config directories that Cloud tries to set in th include file.
+            - echo "\$config_directories = [];
+            # Use the existing `config` directory we already have.
+            - echo "\$config_directories['sync'] = '../config';" >> docroot/sites/default/settings.php

--- a/acquia-pipelines.yml
+++ b/acquia-pipelines.yml
@@ -23,13 +23,6 @@ events:
           type: script
           script:
             # Setup settings file and codebase with minimum required for cloud.
-            - ls -la config
-            - rm -rf config
-            - mkdir -p config/sync
-            - mkdir config/vcs
-            - chmod -R 775 config
-            - ls -la config
             - chmod -R +w docroot/sites/default
             - cp docroot/sites/default/default.settings.php docroot/sites/default/settings.php
             - echo "if (file_exists('/var/www/site-php')) { require '/var/www/site-php/lightningnightly/lightningnightly-settings.inc';}" >> docroot/sites/default/settings.php
-            - echo "\$config_directories['sync'] = '../config/sync';" >> docroot/sites/default/settings.php

--- a/acquia-pipelines.yml
+++ b/acquia-pipelines.yml
@@ -27,7 +27,7 @@ events:
             - rm -rf config
             - mkdir -p config/sync
             - mkdir config/vcs
-            - chmod -R +w config
+            - chmod -R 775 config
             - ls -la config
             - chmod -R +w docroot/sites/default
             - cp docroot/sites/default/default.settings.php docroot/sites/default/settings.php

--- a/acquia-pipelines.yml
+++ b/acquia-pipelines.yml
@@ -27,6 +27,7 @@ events:
             - rm -rf config
             - mkdir -p config/sync
             - mkdir config/vcs
+            - chmod -R +w config
             - ls -la config
             - chmod -R +w docroot/sites/default
             - cp docroot/sites/default/default.settings.php docroot/sites/default/settings.php

--- a/acquia-pipelines.yml
+++ b/acquia-pipelines.yml
@@ -19,15 +19,12 @@ events:
             - export PATH="$HOME/.composer/vendor/bin:$SOURCE_DIR/vendor/bin:$PATH"
             - composer validate --no-check-all --ansi --no-interaction
             - composer update
-      - install:
-          type: script
-          script:
-            - cd $SOURCE_DIR
-            - mysql -u root -proot -e 'CREATE DATABASE drupal;'
-            - lightning install 'mysql\://root:root@localhost/drupal' lightning 'http://127.0.0.1:8080'
       - cleanup:
           type: script
           script:
-            - cd $SOURCE_DIR
             # Setup settings file and codebase with minimum required for cloud.
-            - lightning configure:cloud
+            - chmod -R +w docroot/sites/default
+            - cp docroot/sites/default/default.settings.php docroot/sites/default/settings.php
+            - echo "if (file_exists('/var/www/site-php')) { require '/var/www/site-php/datdemos/lightningnightly-settings.inc';}" >> docroot/sites/default/settings.php
+            - echo "\$config_directories['sync'] = '../config/sync';" >> docroot/sites/default/settings.php
+


### PR DESCRIPTION
The Pipelines config file (`acquia-pipelines.yml`) is used to prepare the codebase to be deployed on Acquia Cloud for testing. It was still using the old `lightning` command to manipulate the codebase. This PR removes use of `lightning` and either removes the superfluous steps that used it, or recreates the functionality within the config file itself.

Here you can see:
* A successful build: https://cloud.acquia.com/app/develop/applications/92170259-5e36-4052-a2ad-0dd5ee5b3ec2/pipelines
* That build successfully deployed: http://lightningnightlyfpce6h2qzh.devcloud.acquia-sites.com/AH_VIEW