### PR TITLE
Allow 1.x and 2.x versions of Acquia Connector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "ext-dom": "*",
         "composer/composer": "^1 || ^2",
         "cweagans/composer-patches": "^1.7",
-        "drupal/acquia_connector": "^2.0-rc1",
+        "drupal/acquia_connector": "^1.24-rc3 || ^2.0-rc1",
         "drupal/core": "~9.1.3",
         "drupal/inline_entity_form": "^1.0-rc7",
         "drupal/lightning_api": "^4.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "12eeeb6901db5b8416b87e5d3cbbb4b0",
+    "content-hash": "d6dde221bf0ebffb143a54a80bc905c1",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
Issue described at: https://www.drupal.org/project/lightning/issues/3197216